### PR TITLE
Fix/validation-error

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,14 +17,19 @@ const app = express();
 
 // added trust proxy
 const rawTrustProxy = process.env.TRUST_PROXY;
-const TRUST_PROXY =
-  rawTrustProxy && rawTrustProxy !== "false"
-    ? isNaN(Number(rawTrustProxy))
-      ? rawTrustProxy === "true"
-        ? true
-        : rawTrustProxy
-      : Number(rawTrustProxy)
-    : 1;
+let TRUST_PROXY: boolean | number | string;
+
+if (!rawTrustProxy) {
+ TRUST_PROXY = 1; 
+} else if (rawTrustProxy === "false") {
+  TRUST_PROXY = false; 
+} else if (rawTrustProxy === "true") {
+  TRUST_PROXY = true; 
+} else if (!isNaN(Number(rawTrustProxy))) {
+  TRUST_PROXY = Number(rawTrustProxy); 
+} else {
+  TRUST_PROXY = rawTrustProxy; 
+}
 
 app.set("trust proxy", TRUST_PROXY);
 


### PR DESCRIPTION
### **Solved the Express 'trust proxy' setting** 
Fixes: #60 

    Change In "index.ts" - added configurable TRUST_PROXY handling to app.set("trust proxy", …) so deployments can match proxy chain while defaulting to 1.

    Result Rate limiting now sees real client IPs and the warning disappears without code edits per environment.

### This image shows the trust proxy config is working.

<img width="653" height="274" alt="image1" src="https://github.com/user-attachments/assets/e1eeca70-d7b0-4018-bae9-1de7de542338" />

### console.log() - I added this just for testing purpose and now I had removed it
<img width="601" height="263" alt="image2" src="https://github.com/user-attachments/assets/37c66de9-0c72-44cb-a461-4c9d389125d2" />

### /debug-ip - I added this also just for testing purpose and now I had removed it
<img width="682" height="196" alt="image3" src="https://github.com/user-attachments/assets/50ace7de-7cd6-426d-9ed5-11cb9f965888" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved API proxy trust handling: app now reads TRUST_PROXY (boolean, numeric, or string) from the environment with an automatic default, altering runtime proxy-trust behavior to better support proxied/distributed deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->