### PR TITLE
fix: competition filter not updating correctly (#148)

### DIFF
--- a/apps/web/src/components/ui/Filter.tsx
+++ b/apps/web/src/components/ui/Filter.tsx
@@ -15,17 +15,14 @@ export default function Filter({
   filters: string[];
   onClick?: () => void;
 }) {
-  const { updateFilters } = useFilterInputStore();
-  const inputData: { [key: string]: string } = {};
+  const { filters: selectedFilters, updateFilters } = useFilterInputStore();
+
   const recordFilterInput = (filter: string) => {
-    inputData[filterName] = filter;
-    updateFilters(inputData);
+    updateFilters({ [filterName]: filter });
   };
 
   const triggerClasses = clsx("text-sm font-medium", {
-    "text-slate-300": ["Hire contributors", "Funding", "Trending"].includes(
-      filterName
-    ),
+    "text-slate-300": ["Hire contributors", "Funding", "Trending"].includes(filterName),
   });
 
   return (
@@ -35,18 +32,21 @@ export default function Filter({
           <span className="text-sm font-medium text-white">{filterName}</span>
         </AccordionTrigger>
         <AccordionContent className="pt-1 pb-3">
-          <RadioGroup className="space-y-3">
+          <RadioGroup
+            className="space-y-3"
+            // ✅ Controlled selection: reads from Zustand state
+            value={selectedFilters[filterName] || ""}
+            onValueChange={(val) => recordFilterInput(val)}
+          >
             {filters.map((filter) => (
               <div key={filter} className="flex items-center space-x-3">
                 <RadioGroupItem
                   value={filter}
-                  id={filter}
-                  onClick={() => recordFilterInput(filter)}
+                  id={`${filterName}-${filter}`}
                   className="border-[#28282c] bg-[#141418] text-ox-purple transition data-[state=checked]:border-ox-purple data-[state=checked]:bg-ox-purple/20 data-[state=checked]:ring-2 data-[state=checked]:ring-ox-purple/50"
                 />
                 <Label
-                  htmlFor={filter}
-                  onClick={() => recordFilterInput(filter)}
+                  htmlFor={`${filterName}-${filter}`}
                   className="text-sm text-zinc-300 cursor-pointer transition-colors"
                 >
                   {filter}

--- a/apps/web/src/store/useFilterInputStore.ts
+++ b/apps/web/src/store/useFilterInputStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
 interface FilterInputState {
-  filters: object;
+  filters: Record<string, string>;
   updateFilters: (newFilter: Record<string, string>) => void;
   resetFilters: () => void;
 }


### PR DESCRIPTION
 Description

This pull request fixes the issue where changing the Competition filter affected the Popularity filter instead of updating its own state.
The bug occurred because a new local object was being created on each render, overwriting previous filter selections.

Changes Made

Removed unnecessary local inputData object inside the Filter component

Used updateFilters({ [filterName]: filter }) to correctly merge filter states

Made the RadioGroup controlled via Zustand state (value + onValueChange)

Ensured each filter (Popularity, Competition, Tech Stack, etc.) updates independently

🧪 Tested Behavior

Selecting different filters now correctly updates their respective categories

No interference between Competition and Popularity filters

Verified persistent selection state across multiple filter groups

🖥️ Issue Reference

Fixes: #148 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved filter state management and component architecture for better code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->