### PR TITLE
feat: add multiple tech stack selection in filters

### DIFF
--- a/apps/web/src/components/ui/Filter.tsx
+++ b/apps/web/src/components/ui/Filter.tsx
@@ -2,6 +2,7 @@
 
 import { AccordionContent, AccordionItem, AccordionTrigger } from "./accordion";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { useFilterInputStore } from "@/store/useFilterInputStore";
 import clsx from "clsx";
@@ -10,16 +11,45 @@ export default function Filter({
   filterName,
   filters,
   onClick,
+  allowMultiple = false,
 }: {
   filterName: string;
   filters: string[];
   onClick?: () => void;
+  allowMultiple?: boolean;
 }) {
-  const { updateFilters } = useFilterInputStore();
-  const inputData: { [key: string]: string } = {};
+  const { updateFilters, updateMultipleFilters, filters: currentFilters } = useFilterInputStore();
+
   const recordFilterInput = (filter: string) => {
-    inputData[filterName] = filter;
-    updateFilters(inputData);
+    if (allowMultiple) {
+      // Handle multiple selection for Tech stack
+      const currentSelected = (currentFilters[filterName] as string[]) || [];
+      const isSelected = currentSelected.includes(filter);
+
+      let newSelected: string[];
+      if (isSelected) {
+        // Remove from selection
+        newSelected = currentSelected.filter((item) => item !== filter);
+      } else {
+        // Add to selection
+        newSelected = [...currentSelected, filter];
+      }
+
+      updateMultipleFilters(filterName, newSelected);
+    } else {
+      // Handle single selection (original behavior)
+      const inputData: { [key: string]: string } = {};
+      inputData[filterName] = filter;
+      updateFilters(inputData);
+    }
+  };
+
+  const isChecked = (filter: string): boolean => {
+    if (allowMultiple) {
+      const currentSelected = (currentFilters[filterName] as string[]) || [];
+      return currentSelected.includes(filter);
+    }
+    return false;
   };
 
   const triggerClasses = clsx("text-sm font-medium", {
@@ -35,25 +65,47 @@ export default function Filter({
           <span className="text-sm font-medium text-white">{filterName}</span>
         </AccordionTrigger>
         <AccordionContent className="pt-1 pb-3">
-          <RadioGroup className="space-y-3">
-            {filters.map((filter) => (
-              <div key={filter} className="flex items-center space-x-3">
-                <RadioGroupItem
-                  value={filter}
-                  id={filter}
-                  onClick={() => recordFilterInput(filter)}
-                  className="border-[#28282c] bg-[#141418] text-ox-purple transition data-[state=checked]:border-ox-purple data-[state=checked]:bg-ox-purple/20 data-[state=checked]:ring-2 data-[state=checked]:ring-ox-purple/50"
-                />
-                <Label
-                  htmlFor={filter}
-                  onClick={() => recordFilterInput(filter)}
-                  className="text-sm text-zinc-300 cursor-pointer transition-colors"
-                >
-                  {filter}
-                </Label>
-              </div>
-            ))}
-          </RadioGroup>
+          {allowMultiple ? (
+            <div className="space-y-3">
+              {filters.map((filter) => (
+                <div key={filter} className="flex items-center space-x-3">
+                  <Checkbox
+                    id={filter}
+                    checked={isChecked(filter)}
+                    onCheckedChange={() => recordFilterInput(filter)}
+                    className="border-[#28282c] bg-[#141418] text-ox-purple transition data-[state=checked]:border-ox-purple data-[state=checked]:bg-ox-purple/20 data-[state=checked]:ring-2 data-[state=checked]:ring-ox-purple/50"
+                  />
+                  <Label
+                    htmlFor={filter}
+                    onClick={() => recordFilterInput(filter)}
+                    className="text-sm text-zinc-300 cursor-pointer transition-colors"
+                  >
+                    {filter}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <RadioGroup className="space-y-3">
+              {filters.map((filter) => (
+                <div key={filter} className="flex items-center space-x-3">
+                  <RadioGroupItem
+                    value={filter}
+                    id={filter}
+                    onClick={() => recordFilterInput(filter)}
+                    className="border-[#28282c] bg-[#141418] text-ox-purple transition data-[state=checked]:border-ox-purple data-[state=checked]:bg-ox-purple/20 data-[state=checked]:ring-2 data-[state=checked]:ring-ox-purple/50"
+                  />
+                  <Label
+                    htmlFor={filter}
+                    onClick={() => recordFilterInput(filter)}
+                    className="text-sm text-zinc-300 cursor-pointer transition-colors"
+                  >
+                    {filter}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
+          )}
         </AccordionContent>
       </AccordionItem>
     </div>

--- a/apps/web/src/components/ui/FiltersContainer.tsx
+++ b/apps/web/src/components/ui/FiltersContainer.tsx
@@ -100,6 +100,7 @@ export default function FiltersContainer() {
                 "Html",
                 "Elixir",
               ]}
+              allowMultiple={true}
             />
             <Filter
               filterName="Popularity"

--- a/apps/web/src/store/useFilterInputStore.ts
+++ b/apps/web/src/store/useFilterInputStore.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 interface FilterInputState {
   filters: object;
   updateFilters: (newFilter: Record<string, string>) => void;
+  updateMultipleFilters: (filterName: string, values: string[]) => void;
   resetFilters: () => void;
 }
 
@@ -11,6 +12,10 @@ export const useFilterInputStore = create<FilterInputState>((set) => ({
   updateFilters: (newFilter) =>
     set((state) => ({
       filters: { ...state.filters, ...newFilter },
+    })),
+  updateMultipleFilters: (filterName, values) =>
+    set((state) => ({
+      filters: { ...state.filters, [filterName]: values },
     })),
   resetFilters: () => set({ filters: {} }),
 }));

--- a/apps/web/src/types/filter.ts
+++ b/apps/web/src/types/filter.ts
@@ -48,7 +48,7 @@ export type ProjectProps = {
 };
 
 export type UserInputFilterProps = {
-  "Tech stack"?: string;
+  "Tech stack"?: string | string[];
   Popularity?: string;
   Competition?: string;
   Stage?: string;

--- a/apps/web/src/utils/converter.ts
+++ b/apps/web/src/utils/converter.ts
@@ -112,7 +112,13 @@ export const convertUserInputToApiInput = (
   const data: Partial<FilterProps> = {};
 
   if (filter["Tech stack"]) {
-    data.language = filter["Tech stack"];
+    // Handle both single string and array of strings
+    if (Array.isArray(filter["Tech stack"])) {
+      // Join multiple languages with space (GitHub search syntax)
+      data.language = filter["Tech stack"].join(" ");
+    } else {
+      data.language = filter["Tech stack"];
+    }
   }
 
   if (filter.Popularity) {


### PR DESCRIPTION
- Replace radio buttons with checkboxes for tech stack filter when allowMultiple is true
- Add updateMultipleFilters method to store to handle array of selected values
- Update Filter component to support both single and multiple selection modes
- Modify UserInputFilterProps type to accept string or string[] for Tech stack
- Update converter logic to handle multiple languages by joining them with space
- Enable allowMultiple prop for Tech stack filter in FiltersContainer

This allows users to select multiple programming languages simultaneously when searching for projects, providing more flexible filtering options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tech stack filter now supports multi-select mode, allowing users to select multiple technologies simultaneously for filtering results.
  * Added Activity filter option to expand filtering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->