### PR TITLE
fix: prevent hidden navbar clicks using pointer-events

### DIFF
--- a/apps/web/src/components/landing-sections/navbar.tsx
+++ b/apps/web/src/components/landing-sections/navbar.tsx
@@ -45,8 +45,8 @@ const Navbar = () => {
 
   return (
     <motion.nav
-      initial={{ opacity: 0 }}
-      animate={showNavbar ? { opacity: 1 } : { opacity: 0 }}
+      initial={{ opacity: 0, pointerEvents: "none" }}
+      animate={showNavbar ? { opacity: 1, pointerEvents: "auto" } : { opacity: 0, pointerEvents: "none" }}
       transition={{ duration: 0.3 }}
       className={cn(
         " z-40  flex items-center justify-between px-4 py-3  bg-neutral-900/5 backdrop-blur-xl  border-white/10",

--- a/apps/web/src/components/landing-sections/navbar.tsx
+++ b/apps/web/src/components/landing-sections/navbar.tsx
@@ -47,6 +47,7 @@ const Navbar = () => {
     <motion.nav
       initial={{ opacity: 0, pointerEvents: "none" }}
       animate={showNavbar ? { opacity: 1, pointerEvents: "auto" } : { opacity: 0, pointerEvents: "none" }}
+      aria-hidden={!showNavbar}
       transition={{ duration: 0.3 }}
       className={cn(
         " z-40  flex items-center justify-between px-4 py-3  bg-neutral-900/5 backdrop-blur-xl  border-white/10",


### PR DESCRIPTION
Fixed issue #152 by adding pointerEvents: "none" to the navbar when it is hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navbar no longer intercepts clicks when hidden, preventing it from blocking other page interactions.
* **Accessibility**
  * Hidden navbar is now exposed as hidden to assistive technologies, improving navigation and screen reader behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->