### PR TITLE
Fix typo in blog title ("shouln't" → "shouldn't")

### DIFF
--- a/apps/web/src/data/blogs.ts
+++ b/apps/web/src/data/blogs.ts
@@ -51,7 +51,7 @@ export const blogs: BlogPost[] = [
   },
   {
     date: "08-11-25",
-    linkText: "why you shouln't register a company?",
+    linkText: "why you shouldn't register a company?",
     link: "https://x.com/ajeetunc/status/1987125877985968217?s=20",
     tag: "startup",
   },


### PR DESCRIPTION
This PR fixes a typo in the blogs data file.

Incorrect:
  "why you shouln't register a company?"

Correct:
  "why you shouldn't register a company?"

This fixes the text shown on the [/blogs](https://opensox.ai/blogs) page.
<img width="710" height="184" alt="issue image" src="https://github.com/user-attachments/assets/dad2fc06-560b-431c-b173-1c679465a7bd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in blog content for improved readability and professionalism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->