### PR TITLE
[fix] don't fail if auth fails for nlr submodule

### DIFF
--- a/apps/web/scripts/init-submodules.sh
+++ b/apps/web/scripts/init-submodules.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
-set +e
+set -e
 
 if [ -n "$GITHUB_TOKEN" ]; then
   echo "Using HTTPS with GitHub token"
+  
+  # Verify token is not empty after trimming
+  if [ -z "${GITHUB_TOKEN// }" ]; then
+    echo "Error: GITHUB_TOKEN is set but empty"
+    exit 1
+  fi
 
   # Overwrite the submodule URL with token-authenticated URL
   git submodule set-url apps/web/src/content/newsletters-premium \
@@ -10,18 +16,29 @@ if [ -n "$GITHUB_TOKEN" ]; then
 
 elif [ -n "$GIT_SSH_KEY" ]; then
   echo "Using SSH key authentication"
+  
+  if [ -z "${GIT_SSH_KEY// }" ]; then
+    echo "Error: GIT_SSH_KEY is set but empty"
+    exit 1
+  fi
+  
+  if ! echo "$GIT_SSH_KEY" | grep -qE "^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521|-----BEGIN)"; then
+    echo "Error: GIT_SSH_KEY does not appear to be a valid SSH key"
+    exit 1
+  fi
+  
   mkdir -p ~/.ssh
   printf '%s' "$GIT_SSH_KEY" > ~/.ssh/id_ed25519
   chmod 600 ~/.ssh/id_ed25519
   ssh-keyscan github.com >> ~/.ssh/known_hosts
+  
 else
   echo "No authentication found! Skipping premium submodule initialization."
   echo "Note: Public newsletters will still work. Premium newsletters require authentication."
   exit 0
 fi
 
-git submodule update --init --recursive --force
-if [ $? -eq 0 ]; then
+if git submodule update --init --recursive --force; then
   echo "Submodules initialized successfully"
 else
   echo "Warning: Submodule initialization failed, but continuing build..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added validation and clearer messaging for repository auth (token/SSH) and adjusted init flow: production failures now stop setup; non‑production emit warnings and continue.
  * Moved TypeScript to runtime dependencies, ensured NODE_ENV is propagated to builds, and updated install behavior to include workspace root.

* **Documentation**
  * Rewrote frontend setup with guided .env example, expanded required variables (API/auth/OAuth), OAuth callback guidance, sample env file, and narrowed env ignore rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->