### PR TITLE
feat: fixed stats count size on small screens

### DIFF
--- a/apps/web/src/components/landing-sections/Brands.tsx
+++ b/apps/web/src/components/landing-sections/Brands.tsx
@@ -29,12 +29,12 @@ const Brands = () => {
       <div className="border-b border flex items-center w-full">
         <div className="relative [box-shadow:0_0_100px_-10px_#14111C_inset] flex items-center justify-center bg-surface-primary w-full border-r border flex-col p-10 md:text-5xl">
           {queryLoading ? (
-            <span className="md:text-7xl text-xl sm:text-4xl text-[clamp(1rem,10vw,6rem)] font-mono tracking-tighter font-medium text-purple-400 animate-pulse">
+            <span className="md:text-8xl md:text-[80px] text-2xl sm:text-5xl text-[clamp(1.5rem,10vw,6rem)] font-mono tracking-tighter font-medium text-purple-400 animate-pulse">
               Loading...
             </span>
           ) : (
             <span
-              className="md:text-7xl text-xl sm:text-4xl relative pointer-events-none text-center bg-gradient-to-b from-brand-purple to-[#341e7b] to-80% bg-clip-text text-transparent text-[clamp(1rem,10vw,6rem)] overflow-hidden font-mono tracking-tighter font-medium"
+              className="md:text-8xl md:text-[80px] text-2xl sm:text-5xl relative pointer-events-none text-center bg-gradient-to-b from-brand-purple to-[#341e7b] to-80% bg-clip-text text-transparent text-[clamp(1.5rem,10vw,6rem)] overflow-hidden font-mono tracking-tighter font-medium"
               style={{
                 textShadow: "0 0 40px rgba(145, 89, 226, 0.5)",
               }}
@@ -49,12 +49,12 @@ const Brands = () => {
         </div>
         <div className="relative flex [box-shadow:0_0_0px_-10px_#14111C_inset] items-center justify-center bg-surface-primary w-full border flex-col p-10 md:text-5xl">
           {userLoading ? (
-            <span className="md:text-7xl text-xl sm:text-4xl text-[clamp(1rem,10vw,6rem)] font-mono tracking-tighter font-medium text-purple-400 animate-pulse">
+            <span className="md:text-8xl md:text-[80px] text-2xl sm:text-5xl text-[clamp(1.5rem,10vw,6rem)] font-mono tracking-tighter font-medium text-purple-400 animate-pulse">
               Loading...
             </span>
           ) : (
             <span
-              className="md:text-7xl text-xl sm:text-4xl relative pointer-events-none text-center bg-gradient-to-b from-brand-purple to-[#341e7b] to-80% bg-clip-text text-transparent text-[clamp(1rem,10vw,6rem)] overflow-hidden font-mono tracking-tighter font-medium"
+              className="md:text-8xl md:text-[80px] text-2xl sm:text-5xl relative pointer-events-none text-center bg-gradient-to-b from-brand-purple to-[#341e7b] to-80% bg-clip-text text-transparent text-[clamp(1.5rem,10vw,6rem)] overflow-hidden font-mono tracking-tighter font-medium"
               style={{
                 textShadow: "0 0 40px rgba(145, 89, 226, 0.5)",
               }}


### PR DESCRIPTION
### Before 
<img width="454" height="817" alt="Screenshot (536)" src="https://github.com/user-attachments/assets/bc855ad3-3670-4851-9de9-60732338fef4" />


### After
<img width="432" height="819" alt="Screenshot (535)" src="https://github.com/user-attachments/assets/22bfda87-9ac5-48e0-9d74-0493ba796239" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted typography in the Brands section for improved visual hierarchy and responsive scaling: larger headings on medium+ screens, refined small-screen scaling, and consistent loading/content heading sizes.
  * Preserved existing fonts, gradient/text effects, shadows and layout—no behavior or interaction changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->