### PR TITLE
Created SponsorCard component for featured projects

### DIFF
--- a/apps/web/src/components/ui/SponsorCard.tsx
+++ b/apps/web/src/components/ui/SponsorCard.tsx
@@ -1,7 +1,6 @@
-import React from "react";
-import { cn } from "@/lib/utils";
 import Image from "next/image";
 import { Card } from "./card";
+import { cn } from "@/lib/utils";
 
 type SponsorCardProps = {
   name: string;
@@ -13,7 +12,7 @@ type SponsorCardProps = {
   openInNewTab?: boolean;
 };
 
-function SponsorCard({
+const SponsorCard = ({
   name,
   description,
   href,
@@ -21,34 +20,33 @@ function SponsorCard({
   logoAlt,
   className,
   openInNewTab = true,
-}: SponsorCardProps) {
+}: SponsorCardProps) => {
 
   return (
     <a
       href={href}
       target={openInNewTab ? "_blank" : undefined}
+      rel={openInNewTab ? "noopener noreferrer" : undefined}
       aria-label={`Visit ${name}`}
       className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <Card
         className={cn(
-          "flex h-full flex-col overflow-hidden border-[#252525] bg-[#111111] text-sm text-muted-foreground/90 [box-shadow:0_0_60px_-24px_#14111C_inset]",
+          "flex h-full flex-col overflow-hidden border-border-primary bg-[#111111] text-sm text-muted-foreground/90 [box-shadow:0_0_60px_-24px_#14111C_inset]",
           "transition-colors hover:border-[#3a3a3a]",
           className
         )}
       >
-        <div className="relative aspect-[4/3] w-full overflow-hidden bg-[#050505]">
+        <div className="relative aspect-[4/3] w-full overflow-hidden bg-background">
           <Image
             src={logoSrc}
             alt={logoAlt ?? `${name} logo`}
             fill
             className="object-contain"
-            unoptimized
-            priority
           />
         </div>
 
-        <div className="border-t border-[#252525] bg-[#050505] px-6 py-4">
+        <div className="border-t border-border-primary bg-background px-6 py-4">
           <p className="text-base font-medium text-foreground">{name}</p>
           <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
             {description}


### PR DESCRIPTION
Fixes #232
1. Needed a shared, reusable card to represent sponsors/companies on both the landing page and dashboard, while staying consistent with the existing design system.
2. Encapsulates the navigation behaviour and styling so consumers only need to pass content and links.

## Implementation Details

- Built on the existing Card primitive from apps/web/src/components/ui/card.tsx.
- Added focus-visible ring and hover border transitions to match the rest of the app’s interactive elements.
- Ensured type-safe props with SponsorCardProps and sensible defaults.

## Manually added cards to landing page to display them


https://github.com/user-attachments/assets/194e31fd-78d6-4d80-b6a0-3ce0f267ab99




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Sponsor Card component that displays sponsor logos, names and descriptions as a clickable card. Includes hover/focus styling and an option to open sponsor links in a new tab for improved navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->