### PR TITLE
Fix: Adjusted font size in Hero banner for better visibility (#256)

### DIFF
--- a/apps/web/src/components/landing-sections/Hero.tsx
+++ b/apps/web/src/components/landing-sections/Hero.tsx
@@ -68,7 +68,7 @@ const Hero = () => {
         </motion.div>
         <motion.h1
           variants={itemVariants}
-          className="text-5xl text-[2.8rem] lg:text-7xl lg:text-[6rem] font-medium tracking-tighter [will-change:transform,opacity] motion-reduce:transition-none motion-reduce:transform-none"
+          className="text-5xl text-[2.8rem] lg:text-7xl lg:text-[5.8rem] font-medium tracking-tighter [will-change:transform,opacity] motion-reduce:transition-none motion-reduce:transform-none"
         >
           Find your perfect Open-Source Repo
         </motion.h1>

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
What I Fixed

Updated the font size in the Hero banner section to improve readability and clarity.

Ensures the text/icon backed by "Users" is now clearly visible.

Why This Fix Was Needed

The original font size was big, making the text/icon in the Hero banner unclear.

Screenshots

Before
<img width="1141" height="615" alt="image" src="https://github.com/user-attachments/assets/6f52d039-4067-457c-a4b7-4eeaeb681f81" />

After
<img width="1140" height="609" alt="image" src="https://github.com/user-attachments/assets/4414ba34-5c50-4d02-a5e0-02b741166833" />

Linked Issue

Closes #256