### PR TITLE
fix(style): make footer responsive on mobile

### DIFF
--- a/apps/web/src/components/landing-sections/footer.tsx
+++ b/apps/web/src/components/landing-sections/footer.tsx
@@ -20,7 +20,7 @@ const Footer = () => {
       {/* Bottom Section */}
       <div className="pt-8 border-t border-[#252525] space-y-8">
         {/* Top Row - Profile Picture and Navigation */}
-        <div className="relative flex items-start justify-between gap-6 lg:gap-0">
+        <div className="relative flex flex-col sm:flex-row items-start justify-between gap-8 lg:gap-6">
           {/* Profile Picture - Left */}
           <div className="flex flex-col gap-4">
             <div>
@@ -44,7 +44,6 @@ const Footer = () => {
               </span>
             </div>
           </div>
-
           {/* Grid Layout - Right */}
           <div className="grid grid-cols-3 gap-6 lg:gap-8">
             {/* Sitemap Column */}


### PR DESCRIPTION
fix: #269 issue

- Fixes landing page footer responsiveness on mobile devices
- Improves layout stacking and spacing for mobile devices

before:
<img width="412" height="690" alt="Screenshot from 2025-12-14 20-19-50" src="https://github.com/user-attachments/assets/93518f75-cdf3-4b43-b0bb-0aba597501c2" />

after:
<img width="355" height="699" alt="Screenshot from 2025-12-14 20-23-26" src="https://github.com/user-attachments/assets/9f0bf799-d386-444f-b9da-0cccd1b79e2c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced footer responsiveness with improved vertical stacking on mobile devices. Optimized spacing between footer sections for better visual hierarchy across all screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->