### PR TITLE
fixed "Get started" button fully not seen issue in hero section.

### DIFF
--- a/apps/web/src/components/landing-sections/Hero.tsx
+++ b/apps/web/src/components/landing-sections/Hero.tsx
@@ -71,12 +71,15 @@ const Hero = () => {
             </div>
           </Link>
         </motion.div>
-        <motion.h1
+        <motion.div
+          initial="hidden"
+          animate="visible"
           variants={itemVariants}
-          className="text-5xl text-[2.8rem] lg:text-7xl lg:text-[6rem] font-medium tracking-tighter [will-change:transform,opacity] motion-reduce:transition-none motion-reduce:transform-none"
         >
-          Only platform you need to get into Open Source
-        </motion.h1>
+          <h1 className="text-5xl lg:text-7xl font-medium tracking-tighter">
+            Only platform you need to get into Open Source
+          </h1>
+        </motion.div>
         <motion.p
           initial={{ opacity: 0, y: 30, filter: "blur(10px)" }}
           animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}


### PR DESCRIPTION
In Hero section "Get started"button was not fully seen in many browser.I have fixed that by increasing it z-index and removing overflow-hidden which was causing that issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured hero section animation implementation for improved code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->