### PR TITLE
fix: resolve clipped get started button in hero section

### DIFF
--- a/apps/web/src/components/landing-sections/Hero.tsx
+++ b/apps/web/src/components/landing-sections/Hero.tsx
@@ -38,7 +38,7 @@ const Hero = () => {
     trackButtonClick("Get Started", "hero");
   };
   return (
-    <div className="w-full min-h-[50dvh] lg:h-[69dvh] relative overflow-hidden z-10 p-4 lg:p-[60px] flex flex-col items-center justify-center gap-6 ">
+    <div className="w-full min-h-[50dvh] lg:min-h-[69dvh] relative overflow-hidden z-10 p-4 lg:p-[60px] flex flex-col items-center justify-center gap-6 ">
       <Image
         src="/assets/bgmain.svg"
         alt="background"
@@ -88,8 +88,9 @@ const Hero = () => {
           }}
           className="w-full lg:text-2xl tracking-tight font-light sm:max-w-lg mx-auto lg:max-w-4xl lg:text-balance text-text-secondary"
         >
-          Find suitabe OSS repos in seconds. learn the basics,
-          get the mentorship for OSS opportunities, GSoC, etc, and start making progress from today itself.
+          Find suitabe OSS repos in seconds. learn the basics, get the
+          mentorship for OSS opportunities, GSoC, etc, and start making progress
+          from today itself.
         </motion.p>
       </motion.div>
       <motion.div

--- a/apps/web/src/components/ui/custom-button.tsx
+++ b/apps/web/src/components/ui/custom-button.tsx
@@ -1,31 +1,41 @@
-"use client"
+"use client";
 
-import { cn } from "@/lib/utils"
-import { motion } from "framer-motion"
-import type React from "react"
+import { cn } from "@/lib/utils";
+import { motion } from "framer-motion";
+import type React from "react";
 
-const PrimaryButton = ({ children, animate = true, classname, onClick }: { children: React.ReactNode, animate?: boolean, classname?: string, onClick?: () => void }) => {
-    const transition = {
-        duration: 0.1,
-        ease: "easeInOut",
-    }
-    return (
-        <motion.button
-            onClick={onClick}
-            className={cn(
-                "flex gap-2 items-center justify-center px-5 py-3 rounded-[16px] relative",
-                "border-x border-t-2 border-brand-purple",
-                "bg-gradient-to-b from-[#5728f4] to-[#5100FF]",
-                "[box-shadow:0px_-2px_0px_0px_#2c04b1_inset]",
-                "hover:opacity-90 transition-opacity duration-100",
-                "text-white font-medium",
-                classname
-            )}
-            transition={animate ? transition : undefined}
-        >
-            {children}
-        </motion.button>
-    )
-}
+const PrimaryButton = ({
+  children,
+  animate = true,
+  classname,
+  onClick,
+}: {
+  children: React.ReactNode;
+  animate?: boolean;
+  classname?: string;
+  onClick?: () => void;
+}) => {
+  const transition = {
+    duration: 0.1,
+    ease: "easeInOut",
+  };
+  return (
+    <motion.button
+      onClick={onClick}
+      className={cn(
+        "flex gap-2 items-center justify-center px-5 py-3 rounded-[16px] relative",
+        "border-x border-t-2 border-brand-purple",
+        "bg-gradient-to-b from-[#5728f4] to-[#5100FF]",
+        "[box-shadow:0px_-2px_0px_0px_#2c04b1_inset]",
+        "hover:opacity-90 transition-opacity duration-100",
+        "text-white font-medium",
+        classname
+      )}
+      transition={animate ? transition : undefined}
+    >
+      {children}
+    </motion.button>
+  );
+};
 
-export default PrimaryButton
+export default PrimaryButton;


### PR DESCRIPTION
## Description
This PR fixes the issue where the "Get Started" button was cut off on desktop screens by changing the Hero section height from fixed to `min-height`.
I have tested the change on multiple browsers and confirmed that the issue is solved , also used the responsive viewer extension to verify that there is no change in responsiveness.

## Related Issue
fixes #300

## Screenshots
<img width="1912" height="1031" alt="image" src="https://github.com/user-attachments/assets/fa737d66-71e5-459c-8d2a-cd8f0134407e" />
<img width="1919" height="1029" alt="image" src="https://github.com/user-attachments/assets/d092c1c5-5fb8-47e6-ae7c-61c7d2ac7b14" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated responsive height styling for improved layout consistency.
  * Normalized code formatting and spacing across components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->