### PR TITLE
fix(navbar): prevent overflow and clipping on small screen widths (#312)

### DIFF
--- a/apps/web/src/components/landing-sections/navbar.tsx
+++ b/apps/web/src/components/landing-sections/navbar.tsx
@@ -103,7 +103,7 @@ const Navbar = () => {
           <span className="whitespace-nowrap">Opensox AI</span>
         </Link>
       </div>
-      <div className="hidden lg:flex items-center gap-2 xl:gap-3 2xl:gap-4 tracking-tight text-sm xl:text-base 2xl:text-lg font-light xl:font-normal text-[#d1d1d1]">
+      <div className="hidden lg:flex items-center gap-2 xl:gap-3 2xl:gap-4 tracking-tight text-sm xl:text-base 2xl:text-lg font-light xl:font-normal text-text-tertiary">
         {links.map((link, index) => {
           const isActive = pathname === link.href;
           return (


### PR DESCRIPTION
## Description
Fixes navbar overflow and clipping on small screen resolutions where navigation items and buttons extend beyond the viewport.

Closes #312

## Changes
- Changed breakpoint from `min-[1115px]` to `lg` (1024px)
- Added progressive responsive scaling with `xl` and `2xl` breakpoints
- Implemented tighter spacing and smaller text sizes at lower breakpoints
- Added `flex-shrink-0` to icons to prevent squishing
- Made logo clickable
- Added client-side mounting check

## Testing
Tested on resolutions from 375px to 1920px+:
- Mobile/Tablet (< 1024px): Hamburger menu
- Small Desktop (1024px - 1279px): All items visible with compact spacing
- Standard Desktop (1280px+): Comfortable spacing

## Screenshots
### Before (1024x768)
<img width="1264" height="866" alt="image" src="https://github.com/user-attachments/assets/af23c1a8-cc9e-4f8b-bc95-de5e97ddff0d" />


### After (1024x768)
<img width="1265" height="862" alt="image" src="https://github.com/user-attachments/assets/548fad7d-4f82-4eb8-91be-aa65fcc83a06" />


## Type of Change
-  Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined navbar layout with responsive width adjustments for pricing vs other pages, improved spacing, font scaling, and text-wrapping to prevent overflow.
  * Polished mobile visuals: tighter toggle sizing, larger touch targets, adjusted paddings/gaps, and enhanced dropdown shadow, max-height/scroll and transition behavior.

* **Bug Fixes**
  * Deferred navbar rendering until initial mount to prevent premature animations/visibility.

* **New Features**
  * Brand/logo now links to the home page for easier navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->