### PR TITLE
fix: make statistics section responsive on mobile

### DIFF
--- a/apps/web/src/components/landing-sections/Brands.tsx
+++ b/apps/web/src/components/landing-sections/Brands.tsx
@@ -24,17 +24,17 @@ const Brands = () => {
     : "0+";
 
   return (
-    <div id="Stats" className="flex flex-col">
+    <div id="Stats" className="flex flex-col overflow-hidden">
       <Header title="Statistics" />
-      <div className="border-b border flex items-center w-full">
-        <div className="relative [box-shadow:0_0_100px_-10px_#14111C_inset] flex items-center justify-center bg-surface-primary w-full border-r border flex-col p-10 md:text-5xl">
+      <div className="border-b flex flex-row items-center w-full">
+        <div className="relative [box-shadow:0_0_100px_-10px_#14111C_inset] flex items-center justify-center bg-surface-primary w-1/2 border-r flex-col px-2 py-8 md:p-10 md:text-5xl">
           {queryLoading ? (
-            <span className="md:text-8xl md:text-[80px] text-2xl sm:text-5xl text-[clamp(1.5rem,10vw,6rem)] font-mono tracking-tighter font-medium text-purple-400 animate-pulse">
+            <span className="md:text-8xl md:text-[80px] text-xl sm:text-5xl text-[clamp(1rem,8vw,6rem)] font-mono tracking-tighter font-medium text-purple-400 animate-pulse">
               Loading...
             </span>
           ) : (
             <span
-              className="md:text-8xl md:text-[80px] text-2xl sm:text-5xl relative pointer-events-none text-center bg-gradient-to-b from-brand-purple to-[#341e7b] to-80% bg-clip-text text-transparent text-[clamp(1.5rem,10vw,6rem)] overflow-hidden font-mono tracking-tighter font-medium"
+              className="md:text-8xl md:text-[80px] text-xl sm:text-5xl relative pointer-events-none text-center bg-gradient-to-b from-brand-purple to-[#341e7b] to-80% bg-clip-text text-transparent text-[clamp(1rem,8vw,6rem)] overflow-hidden font-mono tracking-tighter font-medium"
               style={{
                 textShadow: "0 0 40px rgba(145, 89, 226, 0.5)",
               }}
@@ -44,17 +44,17 @@ const Brands = () => {
           )}
           <span
             style={{ "--text": "Opensox" } as any}
-            className=" relative pointer-events-none text-center before:bg-gradient-to-b before:from-brand-purple before:to-[#321D76] before:to-80% before:bg-clip-text before:text-transparent before:content-['Queries'] after:absolute after:inset-0 after:bg-purple-600 after:bg-clip-text after:text-transparent after:mix-blend-lighten after:content-['Queries'] after:[text-shadow:0_1px_0_black] overflow-hidden font-mono tracking-tighter font-medium text-3xl md:text-5xl"
+            className=" relative pointer-events-none text-center before:bg-gradient-to-b before:from-brand-purple before:to-[#321D76] before:to-80% before:bg-clip-text before:text-transparent before:content-['Queries'] after:absolute after:inset-0 after:bg-purple-600 after:bg-clip-text after:text-transparent after:mix-blend-lighten after:content-['Queries'] after:[text-shadow:0_1px_0_black] overflow-hidden font-mono tracking-tighter font-medium text-lg sm:text-3xl md:text-5xl"
           ></span>
         </div>
-        <div className="relative flex [box-shadow:0_0_0px_-10px_#14111C_inset] items-center justify-center bg-surface-primary w-full border flex-col p-10 md:text-5xl">
+        <div className="relative flex [box-shadow:0_0_0px_-10px_#14111C_inset] items-center justify-center bg-surface-primary w-1/2 flex-col px-2 py-8 md:p-10 md:text-5xl">
           {userLoading ? (
-            <span className="md:text-8xl md:text-[80px] text-2xl sm:text-5xl text-[clamp(1.5rem,10vw,6rem)] font-mono tracking-tighter font-medium text-purple-400 animate-pulse">
+            <span className="md:text-8xl md:text-[80px] text-xl sm:text-5xl text-[clamp(1rem,8vw,6rem)] font-mono tracking-tighter font-medium text-purple-400 animate-pulse">
               Loading...
             </span>
           ) : (
             <span
-              className="md:text-8xl md:text-[80px] text-2xl sm:text-5xl relative pointer-events-none text-center bg-gradient-to-b from-brand-purple to-[#341e7b] to-80% bg-clip-text text-transparent text-[clamp(1.5rem,10vw,6rem)] overflow-hidden font-mono tracking-tighter font-medium"
+              className="md:text-8xl md:text-[80px] text-xl sm:text-5xl relative pointer-events-none text-center bg-gradient-to-b from-brand-purple to-[#341e7b] to-80% bg-clip-text text-transparent text-[clamp(1rem,8vw,6rem)] overflow-hidden font-mono tracking-tighter font-medium"
               style={{
                 textShadow: "0 0 40px rgba(145, 89, 226, 0.5)",
               }}
@@ -64,7 +64,7 @@ const Brands = () => {
           )}
           <span
             style={{ "--text": "Opensox" } as any}
-            className=" relative pointer-events-none text-center before:bg-gradient-to-b before:from-brand-purple before:to-[#321D76] before:to-80% before:bg-clip-text before:text-transparent before:content-['Users'] after:absolute after:inset-0 after:bg-purple-600 after:bg-clip-text after:text-transparent after:mix-blend-lighten after:content-['Users'] after:[text-shadow:0_1px_0_black] overflow-hidden font-mono tracking-tighter font-medium text-3xl md:text-5xl"
+            className=" relative pointer-events-none text-center before:bg-gradient-to-b before:from-brand-purple before:to-[#321D76] before:to-80% before:bg-clip-text before:text-transparent before:content-['Users'] after:absolute after:inset-0 after:bg-purple-600 after:bg-clip-text after:text-transparent after:mix-blend-lighten after:content-['Users'] after:[text-shadow:0_1px_0_black] overflow-hidden font-mono tracking-tighter font-medium text-lg sm:text-3xl md:text-5xl"
           ></span>
         </div>
       </div>


### PR DESCRIPTION
## Description
This PR fixes a responsiveness issue in the statistics section where content was getting cut off on smaller screen sizes.

## Changes
- Removed fixed widths causing overflow
- Updated layout to use responsive styles
- Verified behavior across common mobile breakpoints

## Screenshots

### Before
![Before – statistics section cut off on mobile](https://github.com/user-attachments/assets/718a88b4-bc90-4c14-bafa-6ad024b9cfc7)

### After
<img
  src="https://github.com/user-attachments/assets/55fc0ac7-bb83-41d8-9166-779abcfc52bd"
  alt="After – statistics section responsive on mobile"
  width="453"
/>

Fixes #314


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Brands section layout to display content in a two-column format for improved visual organization.
  * Refined text sizing across the section with enhanced responsive scaling for better readability across devices.
  * Adjusted spacing and styling for a more cohesive and polished appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->