### PR TITLE
Optimize: Reduced LCP time

### DIFF
--- a/apps/web/src/components/landing-sections/Hero.tsx
+++ b/apps/web/src/components/landing-sections/Hero.tsx
@@ -71,12 +71,15 @@ const Hero = () => {
             </div>
           </Link>
         </motion.div>
-        <motion.h1
+        <motion.div
+          initial="hidden"
+          animate="visible"
           variants={itemVariants}
-          className="text-5xl text-[2.8rem] lg:text-7xl lg:text-[6rem] font-medium tracking-tighter [will-change:transform,opacity] motion-reduce:transition-none motion-reduce:transform-none"
         >
-          Only platform you need to get into Open Source
-        </motion.h1>
+          <h1 className="text-5xl lg:text-7xl font-medium tracking-tighter">
+            Only platform you need to get into Open Source
+          </h1>
+        </motion.div>
         <motion.p
           initial={{ opacity: 0, y: 30, filter: "blur(10px)" }}
           animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}


### PR DESCRIPTION
About Fix:

1. Initially LCP was too high...
   
<img width="1247" height="579" alt="image_2025-12-29_212710607" src="https://github.com/user-attachments/assets/5c950c99-6d22-4d3c-acad-23c0d26feb3a" />

2. So i animated wrapper, not h1.
3. LCP fires immediately
4.  Animation still works
<img width="1087" height="545" alt="image_2025-12-29_212749795" src="https://github.com/user-attachments/assets/f6e90ce9-55bd-4252-bd43-bba6aaddbcff" />

     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted animation handling and responsive typography styling in the Hero section heading. The layout and content remain unchanged, with animation responsibility redistributed for improved structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->