### PR TITLE
feat: add smooth scroll to hero section on logo click

### DIFF
--- a/apps/web/src/components/landing-sections/Hero.tsx
+++ b/apps/web/src/components/landing-sections/Hero.tsx
@@ -38,7 +38,7 @@ const Hero = () => {
     trackButtonClick("Get Started", "hero");
   };
   return (
-    <div className="w-full min-h-[50dvh] lg:h-[75dvh] relative overflow-hidden z-10 p-4 lg:p-[60px] flex flex-col items-center justify-center gap-6 ">
+    <div id="hero" className="w-full min-h-[50dvh] lg:h-[75dvh] relative overflow-hidden z-10 p-4 lg:p-[60px] flex flex-col items-center justify-center gap-6 ">
       <Image
         src="/assets/bgmain.svg"
         alt="background"

--- a/apps/web/src/components/landing-sections/navbar.tsx
+++ b/apps/web/src/components/landing-sections/navbar.tsx
@@ -10,6 +10,16 @@ import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/hooks/useAnalytics";
 
 const Navbar = () => {
+    // Scroll to top of hero section
+    const handleLogoClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      e.preventDefault();
+      const hero = document.getElementById('hero');
+      if (hero) {
+        hero.scrollIntoView({ behavior: 'smooth' });
+      } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    };
   const { scrollYProgress } = useScroll();
   const pathname = usePathname();
   const isPricingPage = pathname === "/pricing";
@@ -78,7 +88,12 @@ const Navbar = () => {
         >
           {isOpen ? <X size={28} /> : <Menu size={28} />}
         </button>
-        <div className="text-xl md:text-2xl font-medium tracking-tighter flex items-center gap-2">
+        <div
+          className="text-xl md:text-2xl font-medium tracking-tighter flex items-center gap-2 cursor-pointer"
+          onClick={handleLogoClick}
+          aria-label="Scroll to top"
+          style={{ userSelect: 'none' }}
+        >
           <div className="w-8 md:w-10 aspect-square overflow-hidden relative">
             <Image
               src="/assets/logo.svg"


### PR DESCRIPTION
This pull request improves the user navigation experience on the landing page by allowing users to smoothly scroll back to the top (the hero section) when clicking the logo in the navbar. The main changes include adding an `id` to the hero section and implementing a click handler for the logo.

**User navigation enhancements:**

* Added an `id="hero"` to the main hero section container in `Hero.tsx` to serve as a scroll target.
* Implemented a `handleLogoClick` function in `navbar.tsx` that smoothly scrolls to the hero section when the logo is clicked, or to the top of the page if the hero section is not found.
* Updated the logo container in the navbar to be clickable, trigger the scroll handler, display a pointer cursor, and include accessibility improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logo is now interactive—click it to smoothly scroll back to the hero section, improving site navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->