### PR TITLE
Fix sidebar icon alignment in collapsed state (#337)

### DIFF
--- a/apps/web/src/components/dashboard/Sidebar.tsx
+++ b/apps/web/src/components/dashboard/Sidebar.tsx
@@ -186,7 +186,9 @@ export default function Sidebar({ overlay = false }: { overlay?: boolean }) {
               }}
             >
               <div
-                className={`w-full h-[44px] flex items-center rounded-md cursor-pointer transition-colors px-2 gap-3 pl-3 group ${
+                className={`w-full h-[44px] flex items-center justify-center rounded-md cursor-pointer transition-colors px-2 gap-3 group ${
+                  isCollapsed ? "" : "pl-3"
+                } ${
                   isActive
                     ? "bg-brand-purple/10 border-l-2 border-brand-purple"
                     : "hover:bg-dash-hover"


### PR DESCRIPTION
Fixes #337

## What
- Fixed uneven sidebar icon alignment in collapsed state
- Ensured consistent spacing and alignment across sidebar states

## Why
Sidebar icons appeared misaligned when the sidebar was collapsed, causing visual inconsistency in the UI.

## Screenshots

### Before

<img width="95" height="388" alt="Screenshot 2026-02-09 221936" src="https://github.com/user-attachments/assets/d71fc552-3fef-4a85-8187-cd6ffe1181d3" />

### After

<img width="103" height="402" alt="Screenshot 2026-02-09 222057" src="https://github.com/user-attachments/assets/7bab2099-defd-4c59-9d93-736532f5cdcc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dashboard sidebar layout behavior with responsive alignment and spacing adjustments when toggling between expanded and collapsed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->