### PR TITLE
Added Feat #332 Search project by name

### DIFF
--- a/apps/api/src/routers/projects.ts
+++ b/apps/api/src/routers/projects.ts
@@ -21,6 +21,7 @@ const filterPropsSchema = z.object({
     .optional(),
   pushed: z.string().optional(),
   created: z.string().optional(),
+  repoName: z.string().optional()
 });
 
 const optionsSchema = z.object({

--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -47,6 +47,10 @@ export const projectService = {
       queryParts.push(`created:${filters.created}`);
     }
 
+    if(filters.repoName) {
+      const trimmedRepoName = filters.repoName.trim();
+      queryParts.push(`${trimmedRepoName} in:name`)
+    }
     // Default fields to filter contributor friendly repos
     queryParts.push(`is:organization`);
     queryParts.push(`is:public`);

--- a/apps/web/src/components/ui/FiltersContainer.tsx
+++ b/apps/web/src/components/ui/FiltersContainer.tsx
@@ -25,7 +25,7 @@ export default function FiltersContainer() {
 
   const { toggleShowFilters } = useFilterStore();
   const { setRenderProjects } = useRenderProjects();
-  const { filters, resetFilters } = useFilterInputStore();
+  const { filters, resetFilters, updateFilters } = useFilterInputStore();
   const { setData, eraseData } = useProjectsData();
   const { setProjectsNotFound } = useProjectsNotFoundStore();
   const getProjects = useGetProjects();
@@ -80,6 +80,16 @@ export default function FiltersContainer() {
         {/* Filter Content */}
         <div className="flex-1 overflow-y-auto py-4">
           <Accordion type="multiple" className="space-y-2">
+            <div className="w-full px-6 flex justify-center h-10">
+              <input 
+                type="text" 
+                placeholder="Enter repository name"
+                className="w-full rounded-md outline-none focus:outline-2 focus:outline-ox-purple px-2"
+                onChange={(e) => {
+                  updateFilters({repoName: e.target.value})
+                }}
+              />
+            </div>
             <Filter
               filterName="Tech stack"
               filters={[

--- a/apps/web/src/types/filter.ts
+++ b/apps/web/src/types/filter.ts
@@ -53,4 +53,5 @@ export type UserInputFilterProps = {
   Competition?: string;
   Stage?: string;
   Activity?: string;
+  repoName?: string; 
 };

--- a/apps/web/src/utils/converter.ts
+++ b/apps/web/src/utils/converter.ts
@@ -94,6 +94,7 @@ const userInputValues: UserFilterObjProps = {
 //   Competition: "High",
 //   Stage: "Very early",
 //   Activity: "Normal",
+//   repoName: "name"
 // };
 
 // API INPUT EXAMPLE
@@ -104,6 +105,7 @@ const userInputValues: UserFilterObjProps = {
 //   forks: { min: "50", max: "1000" },
 //   pushed: ">=2024-12-08",
 //   created: ">=2024-12-12",
+//   reponame: "name"
 // };
 
 export const convertUserInputToApiInput = (
@@ -133,7 +135,9 @@ export const convertUserInputToApiInput = (
   if (filter.Stage) {
     data.created = userInputValues.Stage[filter.Stage as keyof StageProps];
   }
-
+  if(filter.repoName) {
+    data.repoName = filter.repoName.trim()
+  }
   return data as FilterProps;
 };
 

--- a/packages/shared/types/filter.ts
+++ b/packages/shared/types/filter.ts
@@ -20,4 +20,5 @@ export type FilterProps = {
     forks?: ForkRange;
     pushed?: string;
     created?: string;
+    repoName?: string
 }


### PR DESCRIPTION
Implemented search project by name

-UI
 Added an input field in find project side bar at the top
 there user can type the name of the repo they want to find

-API
 Added repoName in zod validation of filterPropsSchema
 added repoName in FilterProps
 sending repo name to the query string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Repository Name Filter**: Users can now filter GitHub projects by repository name through a new input field in the filters section. This enhancement integrates seamlessly with existing filter options such as technology stack and popularity, enabling more precise and efficient project discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->