### PR TITLE
fix: add scroll-to-top behaviour for navbar logo

### DIFF
--- a/apps/web/src/components/landing-sections/navbar.tsx
+++ b/apps/web/src/components/landing-sections/navbar.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/hooks/useAnalytics";
+import { useRouter } from "next/navigation";
 
 const Navbar = () => {
   const { scrollYProgress } = useScroll();
@@ -16,6 +17,7 @@ const Navbar = () => {
   const [showNavbar, setShowNavbar] = useState(isPricingPage ? true : false);
   const [isOpen, setIsOpen] = useState(false);
   const { trackButtonClick, trackLinkClick } = useAnalytics();
+  const router = useRouter();
 
   const handleGetStartedClick = (location: "navbar" | "mobile_menu") => {
     trackButtonClick("Get Started", location);
@@ -78,7 +80,13 @@ const Navbar = () => {
         >
           {isOpen ? <X size={28} /> : <Menu size={28} />}
         </button>
-        <div className="text-xl md:text-2xl font-medium tracking-tighter flex items-center gap-2">
+        <div className="text-xl md:text-2xl font-medium tracking-tighter flex items-center gap-2 cursor-pointer" onClick={() => {
+          if(pathname === "/") {
+            window.scrollTo({top: 0, behavior: "smooth"});
+          } else{ 
+            router.push("/");
+          }
+        }}>
           <div className="w-8 md:w-10 aspect-square overflow-hidden relative">
             <Image
               src="/assets/logo.svg"


### PR DESCRIPTION
Fixes #331 

Hello, I noticed that this issue has been open for a while, so I went ahead and worked on it.

Clicking the navbar logo now scrolls to the top of the page (hero section). Also handles navigation if on a different route.
Let me know if anything should be changed. Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the navbar logo clickable for improved navigation - clicking it returns to the home page or smoothly scrolls to the top when already viewing the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->