### PR TITLE
fix: ensure Get Started button is fully visible in hero section (fixes #300)

### DIFF
--- a/apps/web/src/components/landing-sections/Hero.tsx
+++ b/apps/web/src/components/landing-sections/Hero.tsx
@@ -38,7 +38,7 @@ const Hero = () => {
     trackButtonClick("Get Started", "hero");
   };
   return (
-    <div className="w-full min-h-[50dvh] lg:h-[75dvh] relative overflow-hidden z-10 p-4 lg:p-[60px] flex flex-col items-center justify-center gap-6 ">
+    <div className="w-full min-h-[50dvh] lg:min-h-[75dvh] relative overflow-hidden z-10 p-4 lg:p-[60px] flex flex-col items-center justify-center gap-6 ">
       <Image
         src="/assets/bgmain.svg"
         alt="background"


### PR DESCRIPTION
### Description
Fixes #[300](https://github.com/apsinghdev/opensox/issues/300)

This PR addresses an issue where the primary "Get Started" CTA button in the hero section is partially hidden or cut off on smaller screens or at 100% zoom.

### Cause
The root of the issue was a combination of `overflow-hidden` and a strict viewport height `lg:h-[75dvh]` on the Hero section container. If the content height natively exceeds 75% of the viewport (which happens easily vertically on laptops, especially with the large typography), the bottom elements overflowed and were clipped, hiding the CTA button.

### Changes Made
- Updated `apps/web/src/components/landing-sections/Hero.tsx` 
- Replaced the strict `lg:h-[75dvh]` constraint with `lg:min-h-[75dvh]`. 
- This ensures the Hero component still maintains the expected optimal baseline layout height on tall screens, while allowing the container to dynamically expand vertically for smaller screens, securing full visibility of the "Get Started" button.

### Testing Instructions
1. Navigate to the landing page at index `/`.
2. Inspect the Hero section down smaller breakpoints and viewport heights.
3. Validate that the "Get Started" button remains fully visible and interactive at the bottom of the section without getting clipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted Hero section layout on large screens to allow for dynamic height based on content requirements rather than a fixed height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->