### PR TITLE
fix: correct logo redirect to homepage from pricing page

### DIFF
--- a/apps/web/src/components/landing-sections/navbar.tsx
+++ b/apps/web/src/components/landing-sections/navbar.tsx
@@ -78,14 +78,17 @@ const Navbar = () => {
         >
           {isOpen ? <X size={28} /> : <Menu size={28} />}
         </button>
-        <Link href="/" className="text-xl md:text-2xl font-medium tracking-tighter flex items-center gap-2">
+        <Link 
+          href="/" 
+          className="text-xl md:text-2xl font-medium tracking-tighter flex items-center gap-2"
+          aria-label="Go to homepage"
+        >
           <div className="w-8 md:w-10 aspect-square overflow-hidden relative">
             <Image
               src="/assets/logo.svg"
               alt="Opensox logo"
               fill
               className="object-cover w-full h-full"
-              aria-label="Go to homepage"
             />
           </div>
           <span>Opensox AI</span>

--- a/apps/web/src/components/landing-sections/navbar.tsx
+++ b/apps/web/src/components/landing-sections/navbar.tsx
@@ -78,17 +78,18 @@ const Navbar = () => {
         >
           {isOpen ? <X size={28} /> : <Menu size={28} />}
         </button>
-        <div className="text-xl md:text-2xl font-medium tracking-tighter flex items-center gap-2">
+        <Link href="/" className="text-xl md:text-2xl font-medium tracking-tighter flex items-center gap-2">
           <div className="w-8 md:w-10 aspect-square overflow-hidden relative">
             <Image
               src="/assets/logo.svg"
-              alt="background"
+              alt="Opensox logo"
               fill
               className="object-cover w-full h-full"
+              aria-label="Go to homepage"
             />
           </div>
           <span>Opensox AI</span>
-        </div>
+        </Link>
       </div>
       <div className="hidden min-[1115px]:flex items-center gap-5 max-[1270px]:gap-4 max-[1173px]:gap-3 tracking-tight text-lg max-[1270px]:text-base max-[1173px]:text-sm font-light max-[1173px]:font-normal text-[#d1d1d1]">
         {links.map((link, index) => {


### PR DESCRIPTION
## Fix: Logo redirect on /pricing page

### Issue
Clicking the logo on /pricing does not navigate users back to the homepage, creating a navigation dead-end.

### Changes
- Wrapped logo with Next.js Link to redirect to `/`
- Fixed incorrect behavior in previous PR (#350) which pointed to `/dashboard/home`
- Improved accessibility by updating alt text

### Result
Users can now navigate back to the homepage via the logo, following standard UX conventions.

Fixes #348
<img width="1919" height="966" alt="home-page" src="https://github.com/user-attachments/assets/dab3a5fc-1911-4189-8b2e-44116af61eb9" />
<img width="1919" height="970" alt="pricing-page" src="https://github.com/user-attachments/assets/f4689dd5-40a7-4bfe-a91a-9361b7c3dc1a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Brand logo now functions as a clickable link to return to the homepage

* **Improvements**
  * Enhanced accessibility with descriptive logo alt text and aria-labels for screen readers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->