### PR TITLE
fix: replace lucide GitHub icon with custom SVG icon

### DIFF
--- a/apps/web/src/components/landing-sections/navbar.tsx
+++ b/apps/web/src/components/landing-sections/navbar.tsx
@@ -3,7 +3,8 @@ import React, { useState } from "react";
 import PrimaryButton from "../ui/custom-button";
 import { motion, useScroll, useMotionValueEvent } from "framer-motion";
 import Image from "next/image";
-import { Terminal, Github, Menu, X } from "lucide-react";
+import { Terminal, Menu, X } from "lucide-react";
+import { Github } from "@/components/icons/icons";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -115,7 +116,7 @@ const Navbar = () => {
           onClick={() => handleContributeClick("navbar")}
           className="hidden min-[1115px]:flex items-center gap-2 px-4 py-2.5 bg-github-bg hover:bg-github-hover transition-colors rounded-lg border border-github-border text-white"
         >
-          <Github className="w-5 h-5" />
+          <div className="w-5 h-5"><Github /></div>
           <span className="text-sm font-medium">Contribute</span>
         </Link>
         <Link
@@ -156,7 +157,7 @@ const Navbar = () => {
             }}
             className="flex items-center gap-2 px-4 py-2 bg-github-bg hover:bg-github-hover rounded-lg border border-github-border text-white transition-colors"
           >
-            <Github className="w-5 h-5" />
+            <div className="w-5 h-5"><Github /></div>
             <span className="text-sm font-medium">Contribute</span>
           </Link>
         </motion.div>


### PR DESCRIPTION
## What does this PR do?
Replaces the `Github` icon from `lucide-react` with a custom branded SVG in the Navbar.

## Changes
- Updated `Github` icon import in `navbar.tsx`

## Before
![Before UI](https://github.com/user-attachments/assets/f79c5058-a05b-48fa-b7f7-34bb7e2f947d)

## After
![After UI](https://github.com/user-attachments/assets/73c0aa5c-20d9-4fd2-9941-5d97b701e0f3)

## Type of change
- [x] UI improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the GitHub icon in the navigation bar to use a custom icon component with improved rendering consistency across desktop and mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->