### PR TITLE
Title: [BUG] Widespread port mismatch (4000 vs 8080) across documentation and environment defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,6 @@ RUN pnpm install --prod
 
 WORKDIR /app/apps/api
 
-EXPOSE 4000
+EXPOSE 8080
 
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Now run the server:
 pnpm run dev
 ```
 
-Voila! Your API server is running on `localhost:4000`.
+Voila! Your API server is running on `localhost:8080`.
 
 Now you can access your app at `http://localhost:3000`.
 
@@ -208,7 +208,7 @@ docker build -t opensox-api .
 3. Run the container with your environment variables:
 
 ```bash
-docker run -p 4000:4000 \
+docker run -p 8080:8080 \
   --env-file apps/api/.env \
   opensox-api
 ```
@@ -216,16 +216,16 @@ docker run -p 4000:4000 \
 Or if you prefer to pass environment variables individually:
 
 ```bash
-docker run -p 4000:4000 \
+docker run -p 8080:8080 \
   -e DATABASE_URL="postgresql://USER:PASSWORD@host.docker.internal:5432/opensox?schema=public" \
   -e JWT_SECRET="your-secret" \
-  -e PORT=4000 \
+  -e PORT=8080 \
   opensox-api
 ```
 
 **Note:** When using Docker, if your database is running on your host machine (not in a container), use `host.docker.internal` instead of `localhost` in your `DATABASE_URL`.
 
-Your API server will be available at `http://localhost:4000`.
+Your API server will be available at `http://localhost:8080`.
 
 ### Using Docker Compose (Optional)
 
@@ -248,11 +248,11 @@ services:
   api:
     build: .
     ports:
-      - "4000:4000"
+      - "8080:8080"
     environment:
       DATABASE_URL: postgresql://opensox:opensox@postgres:5432/opensox?schema=public
       JWT_SECRET: your-secret-key
-      PORT: 4000
+      PORT: 8080
       NODE_ENV: production
     depends_on:
       - postgres

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,7 +18,7 @@ import { SUBSCRIPTION_STATUS } from "./constants/subscription.js";
 dotenv.config();
 
 const app = express();
-const PORT = process.env.PORT || 4000;
+const PORT = process.env.PORT || 8080;
 const CORS_ORIGINS = process.env.CORS_ORIGINS
   ? process.env.CORS_ORIGINS.split(",")
   : ["http://localhost:3000", "http://localhost:5000"];


### PR DESCRIPTION
---

**Documentation Mismatch: API Port Inconsistency (4000 vs 8080)**

**Description**

There is a significant mismatch in the README.md regarding the port used by the API server.

The documentation frequently references port 4000, while the default configurations in .env.example, the actual environment variables, and the frontend setup are hardcoded to use port 8080.

This inconsistency creates confusion and causes two major failure points for new developers:

**1. Docker Routing Failure**  
When following the Docker instructions, the command `docker run -p 4000:4000 --env-file apps/api/.env opensox-api` is used. However, the .env file sets PORT=8080 by default. The container listens on port 8080 internally, but Docker only maps host port 4000. This results in a "Connection refused" error when trying to access the API.

**2. Frontend Connection Failure**  
The "Local Run" section in the documentation claims the API runs on localhost:4000. In reality, when using default environment variables, the API starts on localhost:8080. Additionally, the frontend's .env.local is configured with NEXT_PUBLIC_API_URL="http://localhost:8080", causing the frontend to fail to connect to the API if the documentation is followed literally.

**Steps to Reproduce**

**Docker Setup**  
1. Copy the default environment variables: cp apps/api/.env.example apps/api/.env  
2. Run the documented Docker command: docker run -p 4000:4000 --env-file apps/api/.env opensox-api  
3. Observe the container logs showing: Listening on port 8080  
4. Try accessing the API at http://localhost:4000 → Connection Refused

**Local Development Setup**  
1. Follow the local setup instructions.  
2. Run `pnpm run dev` in the apps/api directory.  
3. The documentation states: "Voila! Your API server is running on localhost:4000."  
4. Actual terminal output shows the server is running on port 8080.

**Expected Behavior**

The documentation should consistently reference the same port that matches the default environment variables and frontend configuration.

**Suggested Fix**

Standardize the entire documentation to use port 8080, as it aligns with:  
- The default value in apps/api/.env.example  
- The PORT variable used by the API server  
- The NEXT_PUBLIC_API_URL in the frontend's .env.local  

This change will eliminate confusion and prevent connection failures for new contributors and developers.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend runtime configuration references to use port 8080 instead of 4000 across local development, Docker, and Docker Compose setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->