### PR TITLE
fix: add metadata to module pages

### DIFF
--- a/apps/web/src/app/(main)/sheet/[moduleId]/page.tsx
+++ b/apps/web/src/app/(main)/sheet/[moduleId]/page.tsx
@@ -3,9 +3,25 @@ import { getSheetModules } from "@/data/sheet";
 import { SheetModuleHeader } from "@/components/sheet/SheetModuleHeader";
 import { SheetContentRenderer } from "@/components/sheet/SheetContentRenderer";
 import styles from "./sheet-content.module.css";
+import { Metadata } from "next";
+import { capitalizeFirstLetter } from "@/lib/utils";
 
 interface PageProps {
   params: Promise<{ moduleId: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { moduleId } = await params;
+
+  const sheetModules = getSheetModules();
+  const sheetModule = sheetModules.find((m) => m.id === moduleId);
+
+  return {
+    title: `${capitalizeFirstLetter(sheetModule?.id || "Modules")}: ${sheetModule?.name || ""} `,
+    description: `This module describes how to ${sheetModule?.name.toLowerCase()}`,
+  };
 }
 
 export default async function SheetModulePage({ params }: PageProps) {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function capitalizeFirstLetter(word: string) {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -5,6 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function capitalizeFirstLetter(word: string) {
+export const capitalizeFirstLetter = (word: string): string => {
   return word.charAt(0).toUpperCase() + word.slice(1);
 }


### PR DESCRIPTION
Fixes: #373 

Correctly shows the module info title and description 

<img width="1125" height="543" alt="image" src="https://github.com/user-attachments/assets/b04252a4-f014-43a4-a8c8-496ed6142cdc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sheet pages now dynamically generate metadata with formatted titles and descriptions based on sheet modules
  * Added a new utility function for string capitalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->