### PR TITLE
feat: Added an next button in the sheet module page

### DIFF
--- a/apps/web/src/app/(main)/sheet/[moduleId]/page.tsx
+++ b/apps/web/src/app/(main)/sheet/[moduleId]/page.tsx
@@ -17,6 +17,12 @@ export default async function SheetModulePage({ params }: PageProps) {
     notFound();
   }
 
+  // Create module info for navigation (without docContent)
+  const modulesInfo = sheetModules.map((m) => ({
+    id: m.id,
+    name: m.name,
+  }));
+
   return (
     <>
       <div className="min-h-screen bg-surface-primary">
@@ -24,6 +30,8 @@ export default async function SheetModulePage({ params }: PageProps) {
           <SheetModuleHeader
             moduleName={sheetModule.name}
             docContent={sheetModule.docContent}
+            currentModuleId={moduleId}
+            modules={modulesInfo}
           />
           <article>
             <header className="mb-8">

--- a/apps/web/src/components/sheet/SheetModuleHeader.tsx
+++ b/apps/web/src/components/sheet/SheetModuleHeader.tsx
@@ -2,19 +2,49 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, Download, Share2, Check } from "lucide-react";
+import { ArrowLeft, ArrowRight, Download, Share2, Check } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+
+interface ModuleInfo {
+  id: string;
+  name: string;
+}
 
 interface SheetModuleHeaderProps {
   moduleName: string;
   docContent: string;
+  currentModuleId?: string;
+  modules?: ModuleInfo[];
 }
 
 export function SheetModuleHeader({
   moduleName,
   docContent,
+  currentModuleId,
+  modules = [],
 }: SheetModuleHeaderProps) {
   const [copied, setCopied] = useState(false);
+
+  // Compute next module
+  const nextModule = (() => {
+    if (!currentModuleId || modules.length === 0) return null;
+
+    const sortedModules = [...modules].sort((a, b) => {
+      const aNum = parseInt(a.id.replace("module-", "")) || 0;
+      const bNum = parseInt(b.id.replace("module-", "")) || 0;
+      return aNum - bNum;
+    });
+
+    const currentIndex = sortedModules.findIndex(
+      (m) => m.id === currentModuleId
+    );
+
+    if (currentIndex === -1 || currentIndex >= sortedModules.length - 1) {
+      return null;
+    }
+
+    return sortedModules[currentIndex + 1];
+  })();
 
   const handleShare = async () => {
     try {
@@ -110,13 +140,24 @@ export function SheetModuleHeader({
 
   return (
     <div className="flex items-center justify-between mb-8">
-      <Link
-        href="/dashboard/sheet"
-        className="inline-flex items-center gap-2 text-brand-purple-light hover:text-brand-purple transition-colors text-sm font-medium"
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Back to Sheet
-      </Link>
+      <div className="flex items-center gap-4">
+        <Link
+          href="/dashboard/sheet"
+          className="inline-flex items-center gap-2 text-brand-purple-light hover:text-brand-purple transition-colors text-sm font-medium"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Sheet
+        </Link>
+        {nextModule && (
+          <Link
+            href={`/sheet/${nextModule.id}`}
+            className="inline-flex items-center gap-2 text-brand-purple-light hover:text-brand-purple transition-colors text-sm font-medium"
+          >
+            Next: {nextModule.name}
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        )}
+      </div>
 
       <div className="flex items-center gap-2">
         {copied && (

--- a/apps/web/src/components/sheet/SheetModuleHeader.tsx
+++ b/apps/web/src/components/sheet/SheetModuleHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight, Download, Share2, Check } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -26,7 +26,7 @@ export function SheetModuleHeader({
   const [copied, setCopied] = useState(false);
 
   // Compute next module
-  const nextModule = (() => {
+  const nextModule = useMemo(() => {
     if (!currentModuleId || modules.length === 0) return null;
 
     const sortedModules = [...modules].sort((a, b) => {
@@ -44,7 +44,7 @@ export function SheetModuleHeader({
     }
 
     return sortedModules[currentIndex + 1];
-  })();
+  }, [currentModuleId, modules]);
 
   const handleShare = async () => {
     try {


### PR DESCRIPTION
Title:
perf: memoize nextModule computation in SheetModuleHeader
Description:
## Summary
**Performance Optimization**: Implemented `useMemo` hook to memoize the `nextModule` computation in the `SheetModuleHeader` component.
## Changes
- Wrapped the `nextModule` computation logic with `useMemo` hook
- Added dependency array `[currentModuleId, modules]` to ensure the memoized value is recalculated only when these dependencies change
- This prevents unnecessary recalculations of the next module on every render
## Performance Benefits
- **Reduced Computation**: The next module lookup algorithm (which includes sorting and filtering) now only runs when `currentModuleId` or `modules` actually change
- **Better Re-render Performance**: Child components and dependent logic won't trigger expensive calculations on every render cycle
- **Improved User Experience**: Especially beneficial when other state changes trigger re-renders of this component
## Files Changed
- `apps/web/src/components/sheet/SheetModuleHeader.tsx` - Added useMemo hook and dependency array
Branch: feat/next-btn → main
The commit has already been made (0c90f75). You can create the PR on GitHub directly using the details above!
<img width="1322" height="227" alt="image" src="https://github.com/user-attachments/assets/417b92a7-bbc6-4723-8985-fd9910d79a26" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sheet pages now include module navigation controls: a "Back to Sheet" link for returning to the module list, and a "Next: {module name}" link for navigating sequentially through available modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apsinghdev/opensox/pull/376)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->