### PR TITLE
fix(api): validate GitHub token before GraphQL requests

### DIFF
--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -9,13 +9,24 @@ import type {
 
 dotenv.config();
 
-const GH_PAT = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+const getGithubPersonalAccessToken = () => {
+  const token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN?.trim();
 
-const graphqlWithAuth = graphql.defaults({
-  headers: {
-    authorization: `token ${GH_PAT}`,
-  },
-});
+  if (!token) {
+    throw new Error(
+      "GITHUB_PERSONAL_ACCESS_TOKEN is required to fetch GitHub projects. Please configure it in apps/api/.env."
+    );
+  }
+
+  return token;
+};
+
+const createGithubClient = () =>
+  graphql.defaults({
+    headers: {
+      authorization: `token ${getGithubPersonalAccessToken()}`,
+    },
+  });
 
 export const projectService = {
   /**
@@ -53,6 +64,7 @@ export const projectService = {
     queryParts.push(`fork:true`);
 
     const searchQueryString = queryParts.join(" ");
+    const graphqlWithAuth = createGithubClient();
 
     const response: GraphQLResponseProps = await graphqlWithAuth(
       `


### PR DESCRIPTION
## Summary
- Add explicit validation for `GITHUB_PERSONAL_ACCESS_TOKEN`
- Avoid creating GitHub GraphQL requests with `token undefined`
- Return a clearer setup error when the required env var is missing

fix for #378 

> first time tried monorepo, let me know if any changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub API authentication token handling with enhanced error reporting for missing configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apsinghdev/opensox/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->