### PR TITLE
fix: send users to login when their session expires

### DIFF
--- a/apps/web/src/lib/auth/handle-auth-error.ts
+++ b/apps/web/src/lib/auth/handle-auth-error.ts
@@ -20,8 +20,10 @@ export function handleAuthError(error: unknown): void {
   if (!isAuthError(error)) return;
   if (isHandlingAuthError) return;
 
-  // Already on login, so there's nowhere to send them.
-  if (window.location.pathname.startsWith("/login")) return;
+  // Already on login, so there's nowhere to send them. Match the /login route
+  // itself (and its subpaths), not lookalikes like /login-help.
+  const { pathname } = window.location;
+  if (pathname === "/login" || pathname.startsWith("/login/")) return;
 
   isHandlingAuthError = true;
 

--- a/apps/web/src/lib/auth/handle-auth-error.ts
+++ b/apps/web/src/lib/auth/handle-auth-error.ts
@@ -1,0 +1,35 @@
+import { TRPCClientError } from "@trpc/client";
+import { signOut } from "next-auth/react";
+
+// An expired or invalid session comes back as UNAUTHORIZED. FORBIDDEN is a
+// different thing: the user is logged in but not allowed (like premium-only
+// routes), so we leave those alone and don't sign anyone out.
+export function isAuthError(error: unknown): boolean {
+  return (
+    error instanceof TRPCClientError && error.data?.code === "UNAUTHORIZED"
+  );
+}
+
+// Only redirect once even if a whole batch of requests fails at the same time.
+let isHandlingAuthError = false;
+
+// When the session expires, any tRPC call starts failing. Clear the stale
+// session and send the user to login, remembering where they were.
+export function handleAuthError(error: unknown): void {
+  if (typeof window === "undefined") return;
+  if (!isAuthError(error)) return;
+  if (isHandlingAuthError) return;
+
+  // Already on login, so there's nowhere to send them.
+  if (window.location.pathname.startsWith("/login")) return;
+
+  isHandlingAuthError = true;
+
+  const callbackUrl = window.location.pathname + window.location.search;
+
+  signOut({ redirect: false }).finally(() => {
+    window.location.href = `/login?callbackUrl=${encodeURIComponent(
+      callbackUrl
+    )}`;
+  });
+}

--- a/apps/web/src/providers/trpc-provider.tsx
+++ b/apps/web/src/providers/trpc-provider.tsx
@@ -1,18 +1,27 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryCache,
+  MutationCache,
+} from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
 import { useState, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import type { Session } from "next-auth";
 import superjson from "superjson";
 import { trpc } from "@/lib/trpc";
+import { handleAuthError } from "@/lib/auth/handle-auth-error";
 
 export function TRPCProvider({ children }: { children: React.ReactNode }) {
   const { data: session } = useSession();
   const [queryClient] = useState(
     () =>
       new QueryClient({
+        // Send the user to login when their session expires (see handleAuthError).
+        queryCache: new QueryCache({ onError: handleAuthError }),
+        mutationCache: new MutationCache({ onError: handleAuthError }),
         defaultOptions: {
           queries: {
             staleTime: 60 * 1000, // 1 minute


### PR DESCRIPTION
Previously, once a session expired the tRPC calls just started failing and the user was left staring at a broken page with no way back in.

Now any UNAUTHORIZED response from tRPC clears the stale session and redirects to login, keeping track of where they were so they land back there after signing in. FORBIDDEN is left alone since that means logged in but not allowed, not expired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling to consistently redirect users to the login page when their session expires or is unauthorized.
  * Added safeguards to avoid duplicate redirects when multiple requests fail at the same time.
  * Preserves the original destination after login and skips redirect if the user is already on the login page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->