### PR TITLE
fix: center sidebar nav icons when collapsed

### DIFF
--- a/apps/web/src/components/dashboard/Sidebar.tsx
+++ b/apps/web/src/components/dashboard/Sidebar.tsx
@@ -192,7 +192,9 @@ export default function Sidebar({ overlay = false }: { overlay?: boolean }) {
               }}
             >
               <div
-                className={`w-full h-[44px] flex items-center rounded-md cursor-pointer transition-colors px-2 gap-3 pl-3 group ${
+                className={`w-full h-[44px] flex items-center rounded-md cursor-pointer transition-colors px-2 group ${
+                  isCollapsed ? "justify-center" : "gap-3 pl-3"
+                } ${
                   isActive
                     ? "bg-brand-purple/10 border-l-2 border-brand-purple"
                     : "hover:bg-dash-hover"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Free-feature sidebar items so they center-align when the sidebar is collapsed, and use the previous spacing/alignment when expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->