### PR TITLE
[fix] vercel's img bs

### DIFF
--- a/apps/web/src/components/features/explore-features-browser-mockup.tsx
+++ b/apps/web/src/components/features/explore-features-browser-mockup.tsx
@@ -50,6 +50,7 @@ export default function ExploreFeaturesBrowserMockup({
             src={imageSrc}
             alt={featureTitle}
             fill
+            unoptimized
             className="object-cover object-top"
             onError={() => setImageError(true)}
             sizes="(max-width: 768px) 100vw, 60vw"

--- a/apps/web/src/components/features/explore-features-image-preview.tsx
+++ b/apps/web/src/components/features/explore-features-image-preview.tsx
@@ -39,6 +39,7 @@ export default function ExploreFeaturesImagePreview({
           alt={featureTitle}
           fill
           priority
+          unoptimized
           className="object-contain object-center"
           onError={() => setImageError(true)}
           sizes="(max-width: 768px) 100vw, 60vw"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image rendering configuration in preview components to disable Next.js image optimization for specific image elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->