### PR TITLE
Feat: add testimonial popup for pro users on dashboard home

### DIFF
--- a/apps/api/src/routers/testimonial.ts
+++ b/apps/api/src/routers/testimonial.ts
@@ -126,4 +126,31 @@ export const testimonialRouter = router({
 
       return result;
     }),
+
+    // get user's testimonial
+    shouldShowPopup: protectedProcedure.query(async ({ ctx }: any) => {
+      const userId = ctx.user.id;
+
+      const { isPaidUser, subscription } = await userService.checkSubscriptionStatus(ctx.db.prisma, userId);
+
+      if(!isPaidUser || !subscription){
+        return {
+          show: false
+        }
+      }
+      const existingTestimonial = await ctx.db.prisma.testimonial.findUnique({
+        where: {
+          userId
+        }
+      })
+      if(existingTestimonial){
+        return {
+          show: false
+        }
+      }
+      const THREE_WEEK_MS = 21 * 24 * 60 * 60 * 1000;
+      const subscriptionAge = Date.now() - subscription.startDate.getTime();
+
+      return { show: subscriptionAge > THREE_WEEK_MS}
+    })
 });

--- a/apps/api/src/routers/testimonial.ts
+++ b/apps/api/src/routers/testimonial.ts
@@ -127,30 +127,41 @@ export const testimonialRouter = router({
       return result;
     }),
 
-    // get user's testimonial
-    shouldShowPopup: protectedProcedure.query(async ({ ctx }: any) => {
-      const userId = ctx.user.id;
+  shouldShowPopup: protectedProcedure.query(async ({ ctx }: any) => {
+    const userId = ctx.user.id;
 
-      const { isPaidUser, subscription } = await userService.checkSubscriptionStatus(ctx.db.prisma, userId);
+    const { isPaidUser } = await userService.checkSubscriptionStatus(
+      ctx.db.prisma,
+      userId
+    );
 
-      if(!isPaidUser || !subscription){
-        return {
-          show: false
-        }
-      }
-      const existingTestimonial = await ctx.db.prisma.testimonial.findUnique({
-        where: {
-          userId
-        }
-      })
-      if(existingTestimonial){
-        return {
-          show: false
-        }
-      }
-      const THREE_WEEK_MS = 21 * 24 * 60 * 60 * 1000;
-      const subscriptionAge = Date.now() - subscription.startDate.getTime();
+    if (!isPaidUser) {
+      return { show: false };
+    }
 
-      return { show: subscriptionAge > THREE_WEEK_MS}
-    })
+    const existingTestimonial = await ctx.db.prisma.testimonial.findUnique({
+      where: { userId },
+    });
+
+    if (existingTestimonial) {
+      return { show: false };
+    }
+
+    // use earliest subscription so renewals do not reset the 3-week clock
+    const earliestSubscription = await ctx.db.prisma.subscription.findFirst({
+      where: { userId },
+      orderBy: { startDate: "asc" },
+      select: { startDate: true },
+    });
+
+    if (!earliestSubscription) {
+      return { show: false };
+    }
+
+    const THREE_WEEK_MS = 21 * 24 * 60 * 60 * 1000;
+    const subscriptionAge =
+      Date.now() - earliestSubscription.startDate.getTime();
+
+    return { show: subscriptionAge > THREE_WEEK_MS };
+  }),
 });

--- a/apps/web/src/app/(main)/dashboard/home/page.tsx
+++ b/apps/web/src/app/(main)/dashboard/home/page.tsx
@@ -23,11 +23,12 @@ const Home = () => {
     initializeState();
   }, [setData, setRenderProjects, setProjectTitle]);
 
-  return ( <>
+  return (
+    <>
       <Dashboard />
-      <TestimonialPopup/>
-      </> 
-    ) ;
+      <TestimonialPopup />
+    </>
+  );
 };
 
 export default Home;

--- a/apps/web/src/app/(main)/dashboard/home/page.tsx
+++ b/apps/web/src/app/(main)/dashboard/home/page.tsx
@@ -6,6 +6,7 @@ import { useProjectsData } from "@/store/useProjectsDataStore";
 import { useRenderProjects } from "@/store/useRenderProjectsStore";
 import { projectsOfTheWeek } from "@/utils/config";
 import { useEffect } from "react";
+import { TestimonialPopup } from "@/components/dashboard/TestimonialPopup";
 
 const Home = () => {
   const { setRenderProjects } = useRenderProjects();
@@ -22,7 +23,11 @@ const Home = () => {
     initializeState();
   }, [setData, setRenderProjects, setProjectTitle]);
 
-  return <Dashboard />;
+  return ( <>
+      <Dashboard />
+      <TestimonialPopup/>
+      </> 
+    ) ;
 };
 
 export default Home;

--- a/apps/web/src/components/dashboard/TestimonialPopup.tsx
+++ b/apps/web/src/components/dashboard/TestimonialPopup.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AnimatePresence, motion } from "framer-motion";
+import { trpc } from "@/lib/trpc";
+import { useAnalytics } from "@/hooks/useAnalytics";
+
+const DISMISS_KEY = "testimonialPopupDismissedAt";
+const COOLDOWN_DAYS = 5;
+
+function isCooldownActive(): boolean {
+  const dismissedAt = localStorage.getItem(DISMISS_KEY);
+  if (!dismissedAt) return false;
+
+  const daysSinceDismissed =
+    (Date.now() - Number(dismissedAt)) / (1000 * 60 * 60 * 24);
+
+  return daysSinceDismissed < COOLDOWN_DAYS;
+}
+
+export const TestimonialPopup = (): JSX.Element | null => {
+  const [dismissed, setDismissed] = useState(true);
+  const router = useRouter();
+  const { trackLinkClick, trackButtonClick } = useAnalytics();
+
+  const { data } = trpc.testimonial.shouldShowPopup.useQuery(undefined, {
+    staleTime: 60 * 60 * 1000,
+  });
+
+  // show popup once eligibility is confirmed and cooldown has passed
+  useEffect(() => {
+    if (data?.show && !isCooldownActive()) {
+      setDismissed(false);
+    }
+  }, [data]);
+
+  const handleDismiss = () => {
+    trackButtonClick("Testimonial Popup Dismissed", "dashboard-home");
+    localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    setDismissed(true);
+  };
+
+  const handleSubmitClick = () => {
+    trackLinkClick("/testimonials/submit", "Share feedback", "dashboard-home", false);
+    router.push("/testimonials/submit");
+  };
+
+  return (
+    <AnimatePresence>
+      {!dismissed && (
+        <motion.div
+          key="testimonial-popup"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="fixed inset-0 flex items-center justify-center z-50 bg-black/40 backdrop-blur-sm"
+          onClick={handleDismiss}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 12, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 12, scale: 0.95 }}
+            transition={{ duration: 0.2 }}
+            className="bg-dash-surface border border-dash-border rounded-xl p-6 shadow-xl w-full max-w-sm mx-4 flex flex-col gap-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Text */}
+            <div className="flex flex-col items-center text-center gap-2">
+              <h2 className="text-text-primary text-base font-semibold">
+                Enjoying Opensox Pro?
+              </h2>
+              <p className="text-text-muted text-sm leading-relaxed">
+                {"You've been with Opensox Pro for a while now — would you mind sharing your experience? It helps others find us and takes less than a minute."}
+              </p>
+            </div>
+  
+            {/* Buttons */}
+            <div className="flex flex-col gap-2 w-full">
+              <button
+                onClick={handleSubmitClick}
+                className="w-full px-4 py-2.5 rounded-lg bg-brand-purple text-text-primary text-sm font-medium hover:opacity-90 transition-opacity"
+              >
+                Share feedback
+              </button>
+              <button
+                onClick={handleDismiss}
+                className="w-full px-4 py-2.5 rounded-lg text-text-muted text-sm hover:text-text-secondary hover:bg-dash-hover transition-colors"
+              >
+                Not now
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/apps/web/src/components/dashboard/TestimonialPopup.tsx
+++ b/apps/web/src/components/dashboard/TestimonialPopup.tsx
@@ -10,13 +10,18 @@ const DISMISS_KEY = "testimonialPopupDismissedAt";
 const COOLDOWN_DAYS = 5;
 
 function isCooldownActive(): boolean {
-  const dismissedAt = localStorage.getItem(DISMISS_KEY);
-  if (!dismissedAt) return false;
+  try {
+    const dismissedAt = localStorage.getItem(DISMISS_KEY);
+    if (!dismissedAt) return false;
 
-  const daysSinceDismissed =
-    (Date.now() - Number(dismissedAt)) / (1000 * 60 * 60 * 24);
+    const daysSinceDismissed =
+      (Date.now() - Number(dismissedAt)) / (1000 * 60 * 60 * 24);
 
-  return daysSinceDismissed < COOLDOWN_DAYS;
+    return daysSinceDismissed < COOLDOWN_DAYS;
+  }catch(error){
+    console.error("Error checking cooldown", error);
+    return false;
+   }
 }
 
 export const TestimonialPopup = (): JSX.Element | null => {
@@ -44,7 +49,12 @@ export const TestimonialPopup = (): JSX.Element | null => {
 
   const handleDismiss = () => {
     trackButtonClick("Testimonial Popup Dismissed", "dashboard-home");
-    localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    try{
+      localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    }catch(error){
+        console.error("Error dismissing testimonial popup", error);
+    }
+    
     setDismissed(true);
   };
 

--- a/apps/web/src/components/dashboard/TestimonialPopup.tsx
+++ b/apps/web/src/components/dashboard/TestimonialPopup.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { useRouter } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
 import { trpc } from "@/lib/trpc";
@@ -8,6 +13,9 @@ import { useAnalytics } from "@/hooks/useAnalytics";
 
 const DISMISS_KEY = "testimonialPopupDismissedAt";
 const COOLDOWN_DAYS = 5;
+const STALE_TIME_MS = 15 * 60 * 1000; // 15 minutes
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 function isCooldownActive(): boolean {
   try {
@@ -18,23 +26,37 @@ function isCooldownActive(): boolean {
       (Date.now() - Number(dismissedAt)) / (1000 * 60 * 60 * 24);
 
     return daysSinceDismissed < COOLDOWN_DAYS;
-  }catch(error){
+  } catch (error) {
     console.error("Error checking cooldown", error);
     return false;
-   }
+  }
 }
 
-export const TestimonialPopup = (): JSX.Element | null => {
+function setCooldown(): void {
+  try {
+    localStorage.setItem(DISMISS_KEY, String(Date.now()));
+  } catch (error) {
+    console.error("Error dismissing testimonial popup", error);
+  }
+}
+
+export const TestimonialPopup = (): JSX.Element => {
   const [dismissed, setDismissed] = useState(true);
   const router = useRouter();
   const { trackLinkClick, trackButtonClick } = useAnalytics();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
-  const { data, isLoading } = trpc.testimonial.shouldShowPopup.useQuery(undefined, {
-    staleTime: 0,
-    gcTime: 0,
-    refetchOnMount: true,
-    refetchOnWindowFocus: true,
-  });
+  const { data, isLoading } = trpc.testimonial.shouldShowPopup.useQuery(
+    undefined,
+    {
+      staleTime: STALE_TIME_MS,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  const isOpen = !dismissed;
 
   // show popup once eligibility is confirmed and cooldown has passed
   useEffect(() => {
@@ -47,70 +69,132 @@ export const TestimonialPopup = (): JSX.Element | null => {
     }
   }, [data, isLoading]);
 
+  // lock body scroll, focus primary button, restore focus on close
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    // defer focus until after paint so the dialog is in the DOM
+    const focusTimer = window.setTimeout(() => {
+      primaryButtonRef.current?.focus();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.body.style.overflow = previousOverflow;
+      previouslyFocusedRef.current?.focus();
+    };
+  }, [isOpen]);
+
   const handleDismiss = () => {
     trackButtonClick("Testimonial Popup Dismissed", "dashboard-home");
-    try{
-      localStorage.setItem(DISMISS_KEY, String(Date.now()));
-    }catch(error){
-        console.error("Error dismissing testimonial popup", error);
-    }
-    
+    setCooldown();
     setDismissed(true);
   };
 
   const handleSubmitClick = () => {
-    trackLinkClick("/testimonials/submit", "Share feedback", "dashboard-home", false);
+    trackLinkClick(
+      "/testimonials/submit",
+      "Share feedback",
+      "dashboard-home",
+      false
+    );
+    setCooldown();
+    setDismissed(true);
     router.push("/testimonials/submit");
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      handleDismiss();
+      return;
+    }
+
+    if (e.key !== "Tab" || !dialogRef.current) return;
+
+    const focusable = Array.from(
+      dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+    ).filter((el) => el.offsetParent !== null);
+
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
   };
 
   return (
     <AnimatePresence>
-      {!dismissed && (
+      {isOpen && (
         <motion.div
           key="testimonial-popup"
+          ref={dialogRef}
           role="dialog"
           aria-modal="true"
           aria-labelledby="testimonial-popup-title"
-          aria-describedby="testimonial-popup-desc" 
+          aria-describedby="testimonial-popup-desc"
+          tabIndex={-1}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
-          className="fixed inset-0 flex items-center justify-center z-50 bg-black/40 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm outline-none"
           onClick={handleDismiss}
-          onKeyDown={(e) => {
-                 if (e.key === "Escape") handleDismiss();
-            }}
+          onKeyDown={handleKeyDown}
         >
           <motion.div
             initial={{ opacity: 0, y: 12, scale: 0.95 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 12, scale: 0.95 }}
             transition={{ duration: 0.2 }}
-            className="bg-dash-surface border border-dash-border rounded-xl p-6 shadow-xl w-full max-w-sm mx-4 flex flex-col gap-5"
+            className="mx-4 flex w-full max-w-sm flex-col gap-5 rounded-xl border border-dash-border bg-dash-surface p-6 shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
-            {/* Text */}
-            <div className="flex flex-col items-center text-center gap-2">
-            <h2 id="testimonial-popup-title" className="text-text-primary text-base font-semibold">
-                Enjoying Opensox Pro?
+            <div className="flex flex-col items-center gap-2 text-center">
+              <h2
+                id="testimonial-popup-title"
+                className="text-lg font-semibold text-text-primary"
+              >
+                hi! sorry for this shit popup?
               </h2>
-              <p id="testimonial-popup-desc" className="text-text-muted text-sm leading-relaxed">
-                {"We hope you've enjoyed using Opensox Pro! If you have a minute, would you mind sharing your experience? Your feedback means a lot to us and helps others find us."}
+              <p
+                id="testimonial-popup-desc"
+                className="text-md leading-relaxed text-text-tertiary"
+              >
+                {
+                  "i manage everything on my own, so reviews from customers like you are the only marketing for Opensox. it helps me pay the rent and keep Opensox alive. i just wanna ask for 2 mins of your time to please leave a review on Opensox Pro. thanks!!"
+                }
               </p>
             </div>
-  
-            {/* Buttons */}
-            <div className="flex flex-col gap-2 w-full">
+
+            <div className="flex w-full flex-col gap-2">
               <button
+                ref={primaryButtonRef}
+                type="button"
                 onClick={handleSubmitClick}
-                className="w-full px-4 py-2.5 rounded-lg bg-brand-purple text-text-primary text-sm font-medium hover:opacity-90 transition-opacity"
+                className="w-full rounded-lg bg-brand-purple px-4 py-2.5 text-sm font-medium text-text-primary transition-opacity hover:opacity-90"
               >
                 Share feedback
               </button>
               <button
+                type="button"
                 onClick={handleDismiss}
-                className="w-full px-4 py-2.5 rounded-lg text-text-muted text-sm hover:text-text-secondary hover:bg-dash-hover transition-colors"
+                className="w-full rounded-lg px-4 py-2.5 text-sm text-text-muted transition-colors hover:bg-dash-hover hover:text-text-secondary"
               >
                 Not now
               </button>

--- a/apps/web/src/components/dashboard/TestimonialPopup.tsx
+++ b/apps/web/src/components/dashboard/TestimonialPopup.tsx
@@ -170,7 +170,7 @@ export const TestimonialPopup = (): JSX.Element => {
                 id="testimonial-popup-title"
                 className="text-lg font-semibold text-text-primary"
               >
-                hi! sorry for this shit popup?
+                hi! sorry for this annoying pop-up.
               </h2>
               <p
                 id="testimonial-popup-desc"

--- a/apps/web/src/components/dashboard/TestimonialPopup.tsx
+++ b/apps/web/src/components/dashboard/TestimonialPopup.tsx
@@ -24,16 +24,23 @@ export const TestimonialPopup = (): JSX.Element | null => {
   const router = useRouter();
   const { trackLinkClick, trackButtonClick } = useAnalytics();
 
-  const { data } = trpc.testimonial.shouldShowPopup.useQuery(undefined, {
-    staleTime: 60 * 60 * 1000,
+  const { data, isLoading } = trpc.testimonial.shouldShowPopup.useQuery(undefined, {
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
   });
 
   // show popup once eligibility is confirmed and cooldown has passed
   useEffect(() => {
-    if (data?.show && !isCooldownActive()) {
-      setDismissed(false);
+    if (!isLoading) {
+      if (data?.show && !isCooldownActive()) {
+        setDismissed(false);
+      } else {
+        setDismissed(true);
+      }
     }
-  }, [data]);
+  }, [data, isLoading]);
 
   const handleDismiss = () => {
     trackButtonClick("Testimonial Popup Dismissed", "dashboard-home");
@@ -72,7 +79,7 @@ export const TestimonialPopup = (): JSX.Element | null => {
                 Enjoying Opensox Pro?
               </h2>
               <p className="text-text-muted text-sm leading-relaxed">
-                {"You've been with Opensox Pro for a while now — would you mind sharing your experience? It helps others find us and takes less than a minute."}
+                {"We hope you've enjoyed using Opensox Pro! If you have a minute, would you mind sharing your experience? Your feedback means a lot to us and helps others find us."}
               </p>
             </div>
   

--- a/apps/web/src/components/dashboard/TestimonialPopup.tsx
+++ b/apps/web/src/components/dashboard/TestimonialPopup.tsx
@@ -68,12 +68,19 @@ export const TestimonialPopup = (): JSX.Element | null => {
       {!dismissed && (
         <motion.div
           key="testimonial-popup"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="testimonial-popup-title"
+          aria-describedby="testimonial-popup-desc" 
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
           className="fixed inset-0 flex items-center justify-center z-50 bg-black/40 backdrop-blur-sm"
           onClick={handleDismiss}
+          onKeyDown={(e) => {
+                 if (e.key === "Escape") handleDismiss();
+            }}
         >
           <motion.div
             initial={{ opacity: 0, y: 12, scale: 0.95 }}
@@ -85,10 +92,10 @@ export const TestimonialPopup = (): JSX.Element | null => {
           >
             {/* Text */}
             <div className="flex flex-col items-center text-center gap-2">
-              <h2 className="text-text-primary text-base font-semibold">
+            <h2 id="testimonial-popup-title" className="text-text-primary text-base font-semibold">
                 Enjoying Opensox Pro?
               </h2>
-              <p className="text-text-muted text-sm leading-relaxed">
+              <p id="testimonial-popup-desc" className="text-text-muted text-sm leading-relaxed">
                 {"We hope you've enjoyed using Opensox Pro! If you have a minute, would you mind sharing your experience? Your feedback means a lot to us and helps others find us."}
               </p>
             </div>


### PR DESCRIPTION
Fixes #428 

Shows a testimonial prompt popup to pro users who have been subscribed for 3+ weeks and have not yet submitted a testimonial, on `/dashboard/home`

Pro user, 3+ weeks, no testimonial - Popup shows
Already submitted testimonial - Never shows again
Dismissed - Reappears after 5 days
Not a pro user - Never shows
Less than 3 weeks on pro - Will not show

[Screencast from 2026-07-09 13-59-00.webm](https://github.com/user-attachments/assets/bb4b7736-e726-42c9-a11d-1d76efbd9709)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “submit testimonial” popup on the dashboard home for eligible paid subscribers.
  - The popup appears when subscription age exceeds 21 days and the user hasn’t submitted a testimonial yet.
  - Offers “Share feedback” (navigates to the submission page) and “Not now”.
  - Dismissing the popup starts a 5-day cooldown so it won’t reappear immediately.
  - Improved modal UX with accessibility behaviors (focus management, Escape/overlay dismissal, and keyboard Tab handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->