### PR TITLE
feat: add pro projects section with drag-orderable admin cms

### DIFF
--- a/apps/api/prisma/migrations/20260710120000_add_pro_projects/migration.sql
+++ b/apps/api/prisma/migrations/20260710120000_add_pro_projects/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "ProProject" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "qualities" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProProject_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProProject_order_idx" ON "ProProject"("order");
+
+-- CreateIndex
+CREATE INDEX "ProProject_createdAt_idx" ON "ProProject"("createdAt");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -201,3 +201,19 @@ model ProRef {
   @@index([category])
   @@index([order])
 }
+
+model ProProject {
+  id        String   @id @default(cuid())
+  name      String
+  url       String
+  // Free-form, multi-line text (tagline + bullet points). Rendered verbatim.
+  qualities String
+  // Admin-controlled position set by drag-reordering in the CMS (lower shows
+  // first). The "#n" users see is derived from this position, not stored.
+  order     Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([order])
+  @@index([createdAt])
+}

--- a/apps/api/src/routers/_app.ts
+++ b/apps/api/src/routers/_app.ts
@@ -8,6 +8,7 @@ import { sessionsRouter } from "./sessions.js";
 import { testimonialRouter } from "./testimonial.js";
 import { modulesRouter } from "./modules.js";
 import { refsRouter } from "./refs.js";
+import { proProjectsRouter } from "./proProjects.js";
 import { adminRouter } from "./admin.js";
 import { z } from "zod";
 
@@ -30,6 +31,7 @@ export const appRouter = router({
   testimonial: testimonialRouter,
   modules: modulesRouter,
   refs: refsRouter,
+  proProjects: proProjectsRouter,
   admin: adminRouter,
 });
 

--- a/apps/api/src/routers/proProjects.ts
+++ b/apps/api/src/routers/proProjects.ts
@@ -7,7 +7,10 @@ import {
   isAdminEmail,
   type ProtectedContext,
 } from "../trpc.js";
-import { proProjectService } from "../services/proProject.service.js";
+import {
+  proProjectService,
+  ReorderValidationError,
+} from "../services/proProject.service.js";
 import { AuthorizationError } from "../services/session.service.js";
 
 const projectUrlSchema = z
@@ -42,6 +45,9 @@ function logProjectMutation(
 function toTRPCError(error: unknown): never {
   if (error instanceof AuthorizationError) {
     throw new TRPCError({ code: "FORBIDDEN", message: error.message });
+  }
+  if (error instanceof ReorderValidationError) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: error.message });
   }
   throw error;
 }
@@ -110,12 +116,16 @@ export const proProjectsRouter = router({
     .mutation(async ({ ctx, input }) => {
       const userId = (ctx as ProtectedContext).user.id;
       logProjectMutation("adminReorder", userId, undefined, "start");
-      const result = await proProjectService.reorderProjects(
-        ctx.db.prisma,
-        input.ids
-      );
-      logProjectMutation("adminReorder", userId, undefined, "success");
-      return result;
+      try {
+        const result = await proProjectService.reorderProjects(
+          ctx.db.prisma,
+          input.ids
+        );
+        logProjectMutation("adminReorder", userId, undefined, "success");
+        return result;
+      } catch (error) {
+        toTRPCError(error);
+      }
     }),
 
   adminDelete: adminProcedure

--- a/apps/api/src/routers/proProjects.ts
+++ b/apps/api/src/routers/proProjects.ts
@@ -24,24 +24,6 @@ const projectInputSchema = z.object({
   qualities: z.string().trim().min(1, "Qualities are required"),
 });
 
-function logProjectMutation(
-  operation: "adminCreate" | "adminUpdate" | "adminDelete" | "adminReorder",
-  userId: string,
-  projectId: string | undefined,
-  phase: "start" | "success"
-): void {
-  console.log(
-    JSON.stringify({
-      event: "pro_project_mutation",
-      operation,
-      userId,
-      projectId,
-      phase,
-      timestamp: new Date().toISOString(),
-    })
-  );
-}
-
 function toTRPCError(error: unknown): never {
   if (error instanceof AuthorizationError) {
     throw new TRPCError({ code: "FORBIDDEN", message: error.message });
@@ -87,42 +69,20 @@ export const proProjectsRouter = router({
   adminCreate: adminProcedure
     .input(projectInputSchema)
     .mutation(async ({ ctx, input }) => {
-      const userId = (ctx as ProtectedContext).user.id;
-      logProjectMutation("adminCreate", userId, undefined, "start");
-      const project = await proProjectService.createProject(
-        ctx.db.prisma,
-        input
-      );
-      logProjectMutation("adminCreate", userId, project.id, "success");
-      return project;
+      return proProjectService.createProject(ctx.db.prisma, input);
     }),
 
   adminUpdate: adminProcedure
     .input(z.object({ id: z.string().min(1), data: projectInputSchema }))
     .mutation(async ({ ctx, input }) => {
-      const userId = (ctx as ProtectedContext).user.id;
-      logProjectMutation("adminUpdate", userId, input.id, "start");
-      const project = await proProjectService.updateProject(
-        ctx.db.prisma,
-        input.id,
-        input.data
-      );
-      logProjectMutation("adminUpdate", userId, project.id, "success");
-      return project;
+      return proProjectService.updateProject(ctx.db.prisma, input.id, input.data);
     }),
 
   adminReorder: adminProcedure
     .input(z.object({ ids: z.array(z.string().min(1)).min(1) }))
     .mutation(async ({ ctx, input }) => {
-      const userId = (ctx as ProtectedContext).user.id;
-      logProjectMutation("adminReorder", userId, undefined, "start");
       try {
-        const result = await proProjectService.reorderProjects(
-          ctx.db.prisma,
-          input.ids
-        );
-        logProjectMutation("adminReorder", userId, undefined, "success");
-        return result;
+        return await proProjectService.reorderProjects(ctx.db.prisma, input.ids);
       } catch (error) {
         toTRPCError(error);
       }
@@ -131,13 +91,6 @@ export const proProjectsRouter = router({
   adminDelete: adminProcedure
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
-      const userId = (ctx as ProtectedContext).user.id;
-      logProjectMutation("adminDelete", userId, input.id, "start");
-      const result = await proProjectService.deleteProject(
-        ctx.db.prisma,
-        input.id
-      );
-      logProjectMutation("adminDelete", userId, input.id, "success");
-      return result;
+      return proProjectService.deleteProject(ctx.db.prisma, input.id);
     }),
 });

--- a/apps/api/src/routers/proProjects.ts
+++ b/apps/api/src/routers/proProjects.ts
@@ -1,0 +1,133 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  router,
+  protectedProcedure,
+  adminProcedure,
+  isAdminEmail,
+  type ProtectedContext,
+} from "../trpc.js";
+import { proProjectService } from "../services/proProject.service.js";
+import { AuthorizationError } from "../services/session.service.js";
+
+const projectUrlSchema = z
+  .string()
+  .trim()
+  .pipe(z.url({ protocol: /^https?$/ }));
+
+const projectInputSchema = z.object({
+  name: z.string().trim().min(1, "Name is required"),
+  url: projectUrlSchema,
+  qualities: z.string().trim().min(1, "Qualities are required"),
+});
+
+function logProjectMutation(
+  operation: "adminCreate" | "adminUpdate" | "adminDelete" | "adminReorder",
+  userId: string,
+  projectId: string | undefined,
+  phase: "start" | "success"
+): void {
+  console.log(
+    JSON.stringify({
+      event: "pro_project_mutation",
+      operation,
+      userId,
+      projectId,
+      phase,
+      timestamp: new Date().toISOString(),
+    })
+  );
+}
+
+function toTRPCError(error: unknown): never {
+  if (error instanceof AuthorizationError) {
+    throw new TRPCError({ code: "FORBIDDEN", message: error.message });
+  }
+  throw error;
+}
+
+export const proProjectsRouter = router({
+  list: protectedProcedure
+    .input(
+      z
+        .object({
+          search: z.string().optional(),
+          page: z.number().int().min(1).optional(),
+          pageSize: z.number().int().min(1).max(50).optional(),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = (ctx as ProtectedContext).user.id;
+      try {
+        return await proProjectService.getProjects(ctx.db.prisma, userId, {
+          search: input?.search,
+          page: input?.page,
+          pageSize: input?.pageSize,
+        });
+      } catch (error) {
+        toTRPCError(error);
+      }
+    }),
+
+  isAdmin: protectedProcedure.query(({ ctx }) => {
+    return isAdminEmail((ctx as ProtectedContext).user.email);
+  }),
+
+  adminList: adminProcedure.query(async ({ ctx }) => {
+    return proProjectService.listAllForAdmin(ctx.db.prisma);
+  }),
+
+  adminCreate: adminProcedure
+    .input(projectInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const userId = (ctx as ProtectedContext).user.id;
+      logProjectMutation("adminCreate", userId, undefined, "start");
+      const project = await proProjectService.createProject(
+        ctx.db.prisma,
+        input
+      );
+      logProjectMutation("adminCreate", userId, project.id, "success");
+      return project;
+    }),
+
+  adminUpdate: adminProcedure
+    .input(z.object({ id: z.string().min(1), data: projectInputSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = (ctx as ProtectedContext).user.id;
+      logProjectMutation("adminUpdate", userId, input.id, "start");
+      const project = await proProjectService.updateProject(
+        ctx.db.prisma,
+        input.id,
+        input.data
+      );
+      logProjectMutation("adminUpdate", userId, project.id, "success");
+      return project;
+    }),
+
+  adminReorder: adminProcedure
+    .input(z.object({ ids: z.array(z.string().min(1)).min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = (ctx as ProtectedContext).user.id;
+      logProjectMutation("adminReorder", userId, undefined, "start");
+      const result = await proProjectService.reorderProjects(
+        ctx.db.prisma,
+        input.ids
+      );
+      logProjectMutation("adminReorder", userId, undefined, "success");
+      return result;
+    }),
+
+  adminDelete: adminProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = (ctx as ProtectedContext).user.id;
+      logProjectMutation("adminDelete", userId, input.id, "start");
+      const result = await proProjectService.deleteProject(
+        ctx.db.prisma,
+        input.id
+      );
+      logProjectMutation("adminDelete", userId, input.id, "success");
+      return result;
+    }),
+});

--- a/apps/api/src/services/admin.service.ts
+++ b/apps/api/src/services/admin.service.ts
@@ -8,8 +8,6 @@ import {
 
 type Db = ExtendedPrismaClient | PrismaClient;
 
-const PRO_PLAN_NAMES = ["Pro", "Pro+"];
-
 function isTransientDbError(error: unknown): boolean {
   if (
     error instanceof PrismaClientKnownRequestError &&
@@ -67,7 +65,7 @@ export const adminService = {
     const now = new Date();
 
     try {
-      const [paidUsers, revenue] = await Promise.all([
+      const [paidUsers, revenue, latestProPayment] = await Promise.all([
         withRetry(
           () =>
             db.user.count({
@@ -76,7 +74,6 @@ export const adminService = {
                   some: {
                     status: SUBSCRIPTION_STATUS.ACTIVE,
                     endDate: { gte: now },
-                    plan: { name: { in: PRO_PLAN_NAMES } },
                   },
                 },
               },
@@ -91,12 +88,26 @@ export const adminService = {
             }),
           "admin revenue aggregate"
         ),
+        withRetry(
+          () =>
+            db.payment.findFirst({
+              where: { status: PAYMENT_STATUS.CAPTURED },
+              orderBy: { createdAt: "desc" },
+              select: {
+                user: {
+                  select: { email: true },
+                },
+              },
+            }),
+          "admin latest pro member"
+        ),
       ]);
 
       return {
         paidUsers,
         totalRevenuePaise: revenue._sum.amount ?? 0,
         currency: "INR",
+        latestProMemberEmail: latestProPayment?.user.email ?? null,
       };
     } catch (error) {
       if (isTransientDbError(error)) {
@@ -108,6 +119,7 @@ export const adminService = {
           paidUsers: 0,
           totalRevenuePaise: 0,
           currency: "INR",
+          latestProMemberEmail: null,
         };
       }
 

--- a/apps/api/src/services/proProject.service.ts
+++ b/apps/api/src/services/proProject.service.ts
@@ -1,0 +1,218 @@
+import type { PrismaClient } from "@prisma/client";
+import type { ExtendedPrismaClient } from "../prisma.js";
+import { SUBSCRIPTION_STATUS } from "../constants/subscription.js";
+import { AuthorizationError } from "./session.service.js";
+
+type Db = ExtendedPrismaClient | PrismaClient;
+
+export interface PublicProProject {
+  id: string;
+  name: string;
+  url: string;
+  qualities: string;
+  order: number;
+  createdAt: Date;
+}
+
+const PUBLIC_PROJECT_SELECT = {
+  id: true,
+  name: true,
+  url: true,
+  qualities: true,
+  order: true,
+  createdAt: true,
+} as const;
+
+type ProjectWhere = {
+  OR?: Array<
+    | { name: { contains: string; mode: "insensitive" } }
+    | { qualities: { contains: string; mode: "insensitive" } }
+  >;
+};
+
+type ProjectOrderBy = Array<
+  { order: "asc" | "desc" } | { createdAt: "asc" | "desc" }
+>;
+
+type ProProjectModel = {
+  count: (args: { where: ProjectWhere }) => Promise<number>;
+  findMany: (args: {
+    where?: ProjectWhere;
+    select?: typeof PUBLIC_PROJECT_SELECT;
+    orderBy?: ProjectOrderBy;
+    skip?: number;
+    take?: number;
+  }) => Promise<PublicProProject[]>;
+  aggregate: (args: {
+    _min: { order: true };
+  }) => Promise<{ _min: { order: number | null } }>;
+  create: (args: {
+    data: { name: string; url: string; qualities: string; order: number };
+  }) => Promise<PublicProProject>;
+  update: (args: {
+    where: { id: string };
+    data: {
+      name?: string;
+      url?: string;
+      qualities?: string;
+      order?: number;
+    };
+  }) => Promise<PublicProProject>;
+  delete: (args: { where: { id: string } }) => Promise<unknown>;
+};
+
+type ProjectTransaction = {
+  (
+    queries: [Promise<number>, Promise<PublicProProject[]>]
+  ): Promise<[number, PublicProProject[]]>;
+  (queries: Array<Promise<unknown>>): Promise<unknown[]>;
+};
+
+function projectDb(db: Db): {
+  proProject: ProProjectModel;
+  $transaction: ProjectTransaction;
+} {
+  return db as unknown as {
+    proProject: ProProjectModel;
+    $transaction: ProjectTransaction;
+  };
+}
+
+export type PaginatedProProjects = {
+  items: PublicProProject[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+
+const DEFAULT_PAGE_SIZE = 21;
+const MAX_PAGE_SIZE = 50;
+
+// Order is managed exclusively by drag-reordering, so it isn't part of the
+// create/update payloads. New projects are prepended (see createProject).
+export type ProProjectInput = {
+  name: string;
+  url: string;
+  qualities: string;
+};
+
+async function assertActiveSubscription(db: Db, userId: string): Promise<void> {
+  const subscription = await db.subscription.findFirst({
+    where: {
+      userId,
+      status: SUBSCRIPTION_STATUS.ACTIVE,
+      endDate: { gte: new Date() },
+    },
+  });
+
+  if (!subscription) {
+    throw new AuthorizationError(
+      "Active subscription required to access projects"
+    );
+  }
+}
+
+export const proProjectService = {
+  async getProjects(
+    db: Db,
+    userId: string,
+    options: {
+      search?: string | undefined;
+      page?: number | undefined;
+      pageSize?: number | undefined;
+    } = {}
+  ): Promise<PaginatedProProjects> {
+    await assertActiveSubscription(db, userId);
+
+    const search = options.search?.trim();
+    const page = Math.max(1, Math.floor(options.page ?? 1));
+    const pageSize = Math.min(
+      MAX_PAGE_SIZE,
+      Math.max(1, Math.floor(options.pageSize ?? DEFAULT_PAGE_SIZE))
+    );
+
+    const where: ProjectWhere = {};
+
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: "insensitive" } },
+        { qualities: { contains: search, mode: "insensitive" } },
+      ];
+    }
+
+    const client = projectDb(db);
+    const [total, items] = await client.$transaction([
+      client.proProject.count({ where }),
+      client.proProject.findMany({
+        where,
+        select: PUBLIC_PROJECT_SELECT,
+        orderBy: [{ order: "asc" }, { createdAt: "desc" }],
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+    ]);
+
+    return {
+      items,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.max(1, Math.ceil(total / pageSize)),
+    };
+  },
+
+  async listAllForAdmin(db: Db) {
+    return projectDb(db).proProject.findMany({
+      orderBy: [{ order: "asc" }, { createdAt: "desc" }],
+    });
+  },
+
+  async createProject(db: Db, input: ProProjectInput) {
+    const client = projectDb(db);
+    // Prepend new projects: give them a position below the current minimum so
+    // an untouched list reads newest-first. Admins can then drag to reorder.
+    const { _min } = await client.proProject.aggregate({
+      _min: { order: true },
+    });
+    const topOrder = (_min.order ?? 0) - 1;
+
+    return client.proProject.create({
+      data: {
+        name: input.name,
+        url: input.url,
+        qualities: input.qualities,
+        order: topOrder,
+      },
+    });
+  },
+
+  async updateProject(db: Db, id: string, input: ProProjectInput) {
+    // order is intentionally omitted — it changes only via reorderProjects.
+    return projectDb(db).proProject.update({
+      where: { id },
+      data: {
+        name: input.name,
+        url: input.url,
+        qualities: input.qualities,
+      },
+    });
+  },
+
+  async deleteProject(db: Db, id: string) {
+    await projectDb(db).proProject.delete({ where: { id } });
+    return { id };
+  },
+
+  // Persist a full ordering. `ids` is the complete list in the new top-to-bottom
+  // order; each project's `order` becomes its index, densifying to 0..n-1.
+  async reorderProjects(db: Db, ids: string[]) {
+    const client = projectDb(db);
+    await client.$transaction(
+      ids.map((id, index) =>
+        client.proProject.update({ where: { id }, data: { order: index } })
+      )
+    );
+    return { count: ids.length };
+  },
+};

--- a/apps/api/src/services/proProject.service.ts
+++ b/apps/api/src/services/proProject.service.ts
@@ -97,6 +97,15 @@ export type ProProjectInput = {
   qualities: string;
 };
 
+// Thrown when a reorder payload isn't a clean permutation of the existing
+// projects. Mapped to a 400 by the router.
+export class ReorderValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReorderValidationError";
+  }
+}
+
 async function assertActiveSubscription(db: Db, userId: string): Promise<void> {
   const subscription = await db.subscription.findFirst({
     where: {
@@ -204,10 +213,29 @@ export const proProjectService = {
     return { id };
   },
 
-  // Persist a full ordering. `ids` is the complete list in the new top-to-bottom
-  // order; each project's `order` becomes its index, densifying to 0..n-1.
+  // Persist a full ordering. `ids` must be the complete set of existing projects,
+  // each exactly once, in the new top-to-bottom order; every project's `order`
+  // becomes its index, densifying to 0..n-1. Reject anything else up front so a
+  // duplicate, partial, or unknown id can't corrupt the ordering mid-transaction.
   async reorderProjects(db: Db, ids: string[]) {
     const client = projectDb(db);
+
+    const unique = new Set(ids);
+    if (unique.size !== ids.length) {
+      throw new ReorderValidationError("Duplicate project ids in reorder request.");
+    }
+
+    const existing = await client.proProject.findMany({});
+    const existingIds = new Set(existing.map((p) => p.id));
+    if (
+      existingIds.size !== unique.size ||
+      ids.some((id) => !existingIds.has(id))
+    ) {
+      throw new ReorderValidationError(
+        "Reorder request must include every project exactly once."
+      );
+    }
+
     await client.$transaction(
       ids.map((id, index) =>
         client.proProject.update({ where: { id }, data: { order: index } })

--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -30,6 +30,11 @@ const ADMIN_SECTIONS = [
     title: "Pro references",
     description: "Manage reference links shown to Pro members.",
   },
+  {
+    href: "/admin/projects",
+    title: "Pro projects",
+    description: "Manage open source projects shown to Pro members.",
+  },
 ] as const;
 
 const AdminHomePage = (): JSX.Element => {

--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -113,6 +113,11 @@ const AdminHomePage = (): JSX.Element => {
                   )
                 : "—"}
             </span>
+            <span className="mx-2 text-dash-border">·</span>
+            Latest pro member:{" "}
+            <span className="text-text-secondary">
+              {stats?.latestProMemberEmail ?? "—"}
+            </span>
           </p>
         </div>
 

--- a/apps/web/src/app/(admin)/admin/projects/_components/ProjectForm.tsx
+++ b/apps/web/src/app/(admin)/admin/projects/_components/ProjectForm.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+
+export type ProjectFormValues = {
+  name: string;
+  url: string;
+  qualities: string;
+};
+
+type ProjectFormProps = {
+  initialValues?: ProjectFormValues;
+  submitLabel: string;
+  isSubmitting: boolean;
+  onSubmitAction: (values: ProjectFormValues) => void;
+  onCancelAction: () => void;
+};
+
+const EMPTY: ProjectFormValues = {
+  name: "",
+  url: "",
+  qualities: "",
+};
+
+const inputClass =
+  "w-full bg-dash-base border border-dash-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:outline-none";
+
+export function ProjectForm({
+  initialValues,
+  submitLabel,
+  isSubmitting,
+  onSubmitAction,
+  onCancelAction,
+}: ProjectFormProps): JSX.Element {
+  const [values, setValues] = useState<ProjectFormValues>(
+    initialValues ?? EMPTY
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const update = <K extends keyof ProjectFormValues>(
+    key: K,
+    value: ProjectFormValues[K]
+  ) => setValues((prev) => ({ ...prev, [key]: value }));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = values.name.trim();
+    const url = values.url.trim();
+    const qualities = values.qualities.trim();
+
+    if (!name || !url || !qualities) {
+      setSubmitError("Name, link, and qualities are required.");
+      return;
+    }
+
+    setSubmitError(null);
+    onSubmitAction({ name, url, qualities });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {submitError ? (
+        <p className="text-red-400 text-sm bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+          {submitError}
+        </p>
+      ) : null}
+
+      <div>
+        <label
+          htmlFor="project-name"
+          className="block text-sm text-text-secondary mb-1.5"
+        >
+          Name
+        </label>
+        <input
+          id="project-name"
+          className={inputClass}
+          value={values.name}
+          onChange={(e) => update("name", e.target.value)}
+          placeholder="e.g. pebbleOS"
+          required
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="project-url"
+          className="block text-sm text-text-secondary mb-1.5"
+        >
+          Link
+        </label>
+        <input
+          id="project-url"
+          type="url"
+          className={inputClass}
+          value={values.url}
+          onChange={(e) => update("url", e.target.value)}
+          placeholder="https://github.com/..."
+          required
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="project-qualities"
+          className="block text-sm text-text-secondary mb-1.5"
+        >
+          Qualities
+        </label>
+        <textarea
+          id="project-qualities"
+          rows={7}
+          className={`${inputClass} resize-y`}
+          value={values.qualities}
+          onChange={(e) => update("qualities", e.target.value)}
+          placeholder={
+            "an operating system for pebble smartwatches\n\n- low level project\n- core lang: C\n- active community"
+          }
+          required
+        />
+        <p className="text-text-muted text-xs mt-1.5">
+          Free-form text. Line breaks are preserved when shown to members.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-brand-purple hover:bg-brand-purple/90 text-text-primary text-sm font-medium transition-colors disabled:opacity-60"
+        >
+          {isSubmitting ? "Saving..." : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onCancelAction}
+          className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-dash-surface border border-dash-border text-text-secondary hover:bg-dash-hover text-sm transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/(admin)/admin/projects/page.tsx
+++ b/apps/web/src/app/(admin)/admin/projects/page.tsx
@@ -48,7 +48,17 @@ const ProjectsCmsPage = (): JSX.Element => {
   if (status === "loading" || (authenticated && adminCheckLoading)) {
     return (
       <CenteredMessage>
-        <div className="w-8 h-8 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+        <div
+          role="status"
+          aria-label="Checking admin access"
+          className="flex flex-col items-center gap-3"
+        >
+          <div
+            aria-hidden="true"
+            className="w-8 h-8 border-2 border-brand-purple border-t-transparent rounded-full animate-spin"
+          />
+          <span className="sr-only">Checking admin access.</span>
+        </div>
       </CenteredMessage>
     );
   }
@@ -175,6 +185,21 @@ function ProjectList({
     reorder.mutate({ ids: items.map((p) => p.id) });
   };
 
+  // Keyboard equivalent of a drag step: move one project up (-1) or down (+1),
+  // marking the list dirty so it commits like a pointer drag does.
+  const moveByKeyboard = (id: string, delta: number) => {
+    setItems((prev) => {
+      const from = prev.findIndex((p) => p.id === id);
+      const to = from + delta;
+      if (from === -1 || to < 0 || to >= prev.length) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      dirtyRef.current = true;
+      return next;
+    });
+  };
+
   if (isError) {
     return (
       <p className="text-text-secondary">
@@ -224,6 +249,7 @@ function ProjectList({
             position={index + 1}
             onEdit={onEdit}
             onCommit={commitOrder}
+            onMove={moveByKeyboard}
             onDelete={(id) => {
               if (window.confirm(`Delete "${project.name}"? This can't be undone.`)) {
                 deleteProject.mutate({ id });
@@ -246,6 +272,7 @@ function ProjectRow({
   onEdit,
   onDelete,
   onCommit,
+  onMove,
   deleting,
 }: {
   project: AdminProject;
@@ -253,9 +280,23 @@ function ProjectRow({
   onEdit: (project: AdminProject) => void;
   onDelete: (id: string) => void;
   onCommit: () => void;
+  onMove: (id: string, delta: number) => void;
   deleting: boolean;
 }): JSX.Element {
   const controls = useDragControls();
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      onMove(project.id, -1);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      onMove(project.id, 1);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      onCommit();
+    }
+  };
 
   return (
     <Reorder.Item
@@ -269,8 +310,9 @@ function ProjectRow({
         <button
           type="button"
           onPointerDown={(e) => controls.start(e)}
-          aria-label={`Drag to reorder ${project.name}`}
-          className="cursor-grab active:cursor-grabbing touch-none text-text-muted hover:text-text-secondary shrink-0"
+          onKeyDown={handleKeyDown}
+          aria-label={`Reorder ${project.name}. Use arrow up and down to move, Enter to save.`}
+          className="cursor-grab active:cursor-grabbing touch-none text-text-muted hover:text-text-secondary shrink-0 rounded focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:outline-none"
         >
           <GripVertical className="w-4 h-4" />
         </button>

--- a/apps/web/src/app/(admin)/admin/projects/page.tsx
+++ b/apps/web/src/app/(admin)/admin/projects/page.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import { Reorder, useDragControls } from "framer-motion";
+import { GripVertical, Pencil, Plus, Trash2 } from "lucide-react";
+
+import { trpc } from "@/lib/trpc";
+
+import { ProjectForm, type ProjectFormValues } from "./_components/ProjectForm";
+
+type AdminProject = {
+  id: string;
+  name: string;
+  url: string;
+  qualities: string;
+  order: number;
+};
+
+type View =
+  | { mode: "list" }
+  | { mode: "create" }
+  | { mode: "edit"; project: AdminProject };
+
+function toFormValues(project: AdminProject): ProjectFormValues {
+  return {
+    name: project.name,
+    url: project.url,
+    qualities: project.qualities,
+  };
+}
+
+const ProjectsCmsPage = (): JSX.Element => {
+  const { status } = useSession();
+  const [view, setView] = useState<View>({ mode: "list" });
+
+  const authenticated = status === "authenticated";
+
+  const {
+    data: isAdmin,
+    isLoading: adminCheckLoading,
+    isError: adminCheckError,
+    error: adminCheckErrorData,
+  } = trpc.proProjects.isAdmin.useQuery(undefined, { enabled: authenticated });
+
+  if (status === "loading" || (authenticated && adminCheckLoading)) {
+    return (
+      <CenteredMessage>
+        <div className="w-8 h-8 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+      </CenteredMessage>
+    );
+  }
+
+  if (!authenticated) {
+    return (
+      <CenteredMessage>
+        <p className="text-text-secondary">You need to sign in to continue.</p>
+        <Link href="/login" className="text-brand-purple-light hover:underline">
+          Go to login
+        </Link>
+      </CenteredMessage>
+    );
+  }
+
+  if (adminCheckError) {
+    return (
+      <CenteredMessage>
+        <p className="text-text-primary font-semibold text-lg">
+          Couldn&apos;t verify admin access
+        </p>
+        <p className="text-text-secondary text-sm">
+          {adminCheckErrorData?.message ??
+            "A temporary error occurred. Please try again."}
+        </p>
+      </CenteredMessage>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <CenteredMessage>
+        <p className="text-text-primary font-semibold text-lg">Access denied</p>
+        <p className="text-text-secondary text-sm">
+          This area is restricted to administrators.
+        </p>
+      </CenteredMessage>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-ox-content">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 md:py-12">
+        <div className="flex items-center justify-between gap-4 mb-8">
+          <div>
+            <h1 className="text-2xl font-bold text-text-primary">
+              Pro Projects CMS
+            </h1>
+            <p className="text-text-secondary text-sm mt-1">
+              Add, edit, and drag to reorder projects shown to Pro members.
+            </p>
+          </div>
+          {view.mode === "list" ? (
+            <button
+              type="button"
+              onClick={() => setView({ mode: "create" })}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-purple hover:bg-brand-purple/90 text-text-primary text-sm font-medium transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              New project
+            </button>
+          ) : null}
+        </div>
+
+        {view.mode === "list" ? (
+          <ProjectList
+            onCreate={() => setView({ mode: "create" })}
+            onEdit={(project) => setView({ mode: "edit", project })}
+          />
+        ) : (
+          <ProjectEditor view={view} onDone={() => setView({ mode: "list" })} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+function CenteredMessage({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <div className="min-h-screen bg-ox-content flex items-center justify-center">
+      <div className="flex flex-col items-center gap-3 text-center px-4">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function ProjectList({
+  onCreate,
+  onEdit,
+}: {
+  onCreate: () => void;
+  onEdit: (project: AdminProject) => void;
+}): JSX.Element {
+  const utils = trpc.useUtils();
+  const { data, isLoading, isError, error } =
+    trpc.proProjects.adminList.useQuery();
+
+  const reorder = trpc.proProjects.adminReorder.useMutation({
+    onError: (e) => window.alert(`Couldn't save the new order: ${e.message}`),
+    onSettled: () => utils.proProjects.adminList.invalidate(),
+  });
+  const deleteProject = trpc.proProjects.adminDelete.useMutation({
+    onSuccess: () => utils.proProjects.adminList.invalidate(),
+    onError: (e) => window.alert(`Couldn't delete the project: ${e.message}`),
+  });
+
+  // Local, drag-controlled copy of the list. Server order is the source of
+  // truth; we sync from it whenever the query resolves or is invalidated.
+  const [items, setItems] = useState<AdminProject[]>([]);
+  const dirtyRef = useRef(false);
+
+  useEffect(() => {
+    if (data) setItems(data);
+  }, [data]);
+
+  const commitOrder = () => {
+    if (!dirtyRef.current) return;
+    dirtyRef.current = false;
+    reorder.mutate({ ids: items.map((p) => p.id) });
+  };
+
+  if (isError) {
+    return (
+      <p className="text-text-secondary">
+        {error?.message ?? "Failed to load projects. Please try again."}
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return <p className="text-text-secondary">Loading projects...</p>;
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="border border-dash-border rounded-xl p-10 text-center">
+        <p className="text-text-secondary">No projects yet.</p>
+        <button
+          type="button"
+          onClick={onCreate}
+          className="mt-4 text-brand-purple-light hover:underline text-sm"
+        >
+          Add your first project
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <p className="text-text-muted text-xs mb-3">
+        Drag the handle to reorder. The order here is exactly what Pro members
+        see (numbered 1 to {items.length}).
+      </p>
+      <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={(next: AdminProject[]) => {
+          setItems(next);
+          dirtyRef.current = true;
+        }}
+        className="space-y-3"
+      >
+        {items.map((project, index) => (
+          <ProjectRow
+            key={project.id}
+            project={project}
+            position={index + 1}
+            onEdit={onEdit}
+            onCommit={commitOrder}
+            onDelete={(id) => {
+              if (window.confirm(`Delete "${project.name}"? This can't be undone.`)) {
+                deleteProject.mutate({ id });
+              }
+            }}
+            deleting={
+              deleteProject.isPending &&
+              deleteProject.variables?.id === project.id
+            }
+          />
+        ))}
+      </Reorder.Group>
+    </>
+  );
+}
+
+function ProjectRow({
+  project,
+  position,
+  onEdit,
+  onDelete,
+  onCommit,
+  deleting,
+}: {
+  project: AdminProject;
+  position: number;
+  onEdit: (project: AdminProject) => void;
+  onDelete: (id: string) => void;
+  onCommit: () => void;
+  deleting: boolean;
+}): JSX.Element {
+  const controls = useDragControls();
+
+  return (
+    <Reorder.Item
+      value={project}
+      dragListener={false}
+      dragControls={controls}
+      onDragEnd={onCommit}
+      className="bg-dash-surface border border-dash-border rounded-xl p-4 flex items-center justify-between gap-4"
+    >
+      <div className="flex items-center gap-3 min-w-0">
+        <button
+          type="button"
+          onPointerDown={(e) => controls.start(e)}
+          aria-label={`Drag to reorder ${project.name}`}
+          className="cursor-grab active:cursor-grabbing touch-none text-text-muted hover:text-text-secondary shrink-0"
+        >
+          <GripVertical className="w-4 h-4" />
+        </button>
+        <div className="min-w-0">
+          <span className="text-xs text-brand-purple-light bg-brand-purple/10 rounded-full px-2 py-0.5">
+            #{position}
+          </span>
+          <p className="text-text-primary font-medium mt-1.5 truncate">
+            {project.name}
+          </p>
+          <p className="text-text-muted text-xs mt-0.5 truncate">
+            {project.url}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          onClick={() => onEdit(project)}
+          aria-label={`Edit ${project.name}`}
+          className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-dash-raised hover:bg-dash-hover transition-colors"
+        >
+          <Pencil className="w-4 h-4 text-text-secondary" />
+        </button>
+        <button
+          type="button"
+          disabled={deleting}
+          onClick={() => onDelete(project.id)}
+          aria-label={`Delete ${project.name}`}
+          className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-dash-raised hover:bg-red-500/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Trash2 className="w-4 h-4 text-text-secondary" />
+        </button>
+      </div>
+    </Reorder.Item>
+  );
+}
+
+function ProjectEditor({
+  view,
+  onDone,
+}: {
+  view: { mode: "create" } | { mode: "edit"; project: AdminProject };
+  onDone: () => void;
+}): JSX.Element {
+  const utils = trpc.useUtils();
+  const [error, setError] = useState<string | null>(null);
+
+  const onSuccess = () => {
+    utils.proProjects.adminList.invalidate();
+    onDone();
+  };
+
+  const createProject = trpc.proProjects.adminCreate.useMutation({
+    onSuccess,
+    onError: (e) => setError(e.message),
+  });
+  const updateProject = trpc.proProjects.adminUpdate.useMutation({
+    onSuccess,
+    onError: (e) => setError(e.message),
+  });
+
+  const isSubmitting = createProject.isPending || updateProject.isPending;
+
+  const handleSubmit = (values: ProjectFormValues) => {
+    setError(null);
+    const payload = {
+      name: values.name,
+      url: values.url,
+      qualities: values.qualities,
+    };
+
+    if (view.mode === "edit") {
+      updateProject.mutate({ id: view.project.id, data: payload });
+    } else {
+      createProject.mutate(payload);
+    }
+  };
+
+  return (
+    <div className="bg-dash-surface border border-dash-border rounded-xl p-5 md:p-6">
+      <h2 className="text-text-primary font-semibold text-lg mb-5">
+        {view.mode === "edit" ? "Edit project" : "New project"}
+      </h2>
+
+      {error ? (
+        <p className="text-red-400 text-sm mb-4 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      ) : null}
+
+      <ProjectForm
+        initialValues={
+          view.mode === "edit" ? toFormValues(view.project) : undefined
+        }
+        submitLabel={view.mode === "edit" ? "Save changes" : "Create project"}
+        isSubmitting={isSubmitting}
+        onSubmitAction={handleSubmit}
+        onCancelAction={onDone}
+      />
+    </div>
+  );
+}
+
+export default ProjectsCmsPage;

--- a/apps/web/src/app/(main)/dashboard/pro/projects/_components/ProjectCard.tsx
+++ b/apps/web/src/app/(main)/dashboard/pro/projects/_components/ProjectCard.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+
+import type { ProProject } from "./project-types";
+
+type ProjectCardProps = {
+  item: ProProject;
+  position: number;
+};
+
+export function ProjectCard({ item, position }: ProjectCardProps): JSX.Element {
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col h-full bg-dash-surface border border-dash-border rounded-xl p-5 hover:border-brand-purple/40 transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:outline-none"
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="min-w-0">
+          <span className="text-xs text-brand-purple-light bg-brand-purple/10 rounded-full px-2 py-0.5">
+            #{position}
+          </span>
+          <h3 className="text-text-primary font-semibold text-base mt-2 truncate">
+            {item.name}
+          </h3>
+        </div>
+        <ExternalLink
+          aria-hidden="true"
+          className="w-4 h-4 shrink-0 mt-0.5 text-text-muted group-hover:text-brand-purple-light transition-colors"
+        />
+      </div>
+
+      <p className="text-text-secondary text-sm whitespace-pre-line leading-relaxed">
+        {item.qualities}
+      </p>
+    </a>
+  );
+}

--- a/apps/web/src/app/(main)/dashboard/pro/projects/_components/project-types.ts
+++ b/apps/web/src/app/(main)/dashboard/pro/projects/_components/project-types.ts
@@ -1,0 +1,3 @@
+import type { PublicProProject } from "../../../../../../../../api/src/services/proProject.service";
+
+export type ProProject = PublicProProject;

--- a/apps/web/src/app/(main)/dashboard/pro/projects/page.tsx
+++ b/apps/web/src/app/(main)/dashboard/pro/projects/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+
+import { useSubscription } from "@/hooks/useSubscription";
+import { trpc } from "@/lib/trpc";
+
+import { ProjectCard } from "./_components/ProjectCard";
+import type { ProProject } from "./_components/project-types";
+
+const PAGE_SIZE = 21;
+
+const ProProjectsPage = (): JSX.Element | null => {
+  const { isPaidUser, isLoading: subscriptionLoading } = useSubscription();
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    if (!subscriptionLoading && !isPaidUser) {
+      router.push("/pricing");
+    }
+  }, [isPaidUser, subscriptionLoading, router]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch]);
+
+  const authenticated = !!session?.user && status === "authenticated";
+
+  const { data, isLoading, isError } = trpc.proProjects.list.useQuery(
+    {
+      search: debouncedSearch || undefined,
+      page,
+      pageSize: PAGE_SIZE,
+    },
+    {
+      enabled: authenticated && isPaidUser,
+      refetchOnWindowFocus: false,
+      staleTime: 60 * 1000,
+    }
+  );
+
+  const projects = data?.items ?? [];
+  const totalPages = data?.totalPages ?? 1;
+
+  const isInitialLoading =
+    subscriptionLoading || (isPaidUser && isLoading && !data);
+
+  if (isInitialLoading) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-ox-content">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-8 h-8 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+          <p className="text-text-secondary text-sm">Loading projects...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isPaidUser) {
+    return null;
+  }
+
+  return (
+    <div className="w-full min-h-full bg-ox-content">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8 md:py-12">
+        <div className="mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-text-primary">
+            Pro Projects
+          </h1>
+          <p className="text-text-secondary text-sm md:text-base mt-2">
+            Hand-picked open source projects worth contributing to.
+          </p>
+        </div>
+
+        <ProjectsContent
+          search={search}
+          onSearchChange={setSearch}
+          projects={projects}
+          isError={isError}
+          page={page}
+          totalPages={totalPages}
+          onPageChange={setPage}
+        />
+      </div>
+    </div>
+  );
+};
+
+type ProjectsContentProps = {
+  search: string;
+  onSearchChange: (value: string) => void;
+  projects: ProProject[];
+  isError: boolean;
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+};
+
+function ProjectsContent({
+  search,
+  onSearchChange,
+  projects,
+  isError,
+  page,
+  totalPages,
+  onPageChange,
+}: ProjectsContentProps): JSX.Element {
+  return (
+    <>
+      <div className="relative mb-6">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          aria-label="Search projects"
+          placeholder="Search projects..."
+          className="w-full bg-dash-surface border border-dash-border rounded-lg pl-9 pr-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:outline-none"
+        />
+      </div>
+
+      {isError ? (
+        <p className="text-text-secondary text-center py-16">
+          Failed to load projects. Please try again later.
+        </p>
+      ) : projects.length > 0 ? (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {projects.map((project, index) => (
+              <ProjectCard
+                key={project.id}
+                item={project}
+                position={(page - 1) * PAGE_SIZE + index + 1}
+              />
+            ))}
+          </div>
+
+          {totalPages > 1 ? (
+            <Pagination
+              page={page}
+              totalPages={totalPages}
+              onPageChange={onPageChange}
+            />
+          ) : null}
+        </>
+      ) : (
+        <p className="text-text-secondary text-center py-16">
+          No projects found.
+        </p>
+      )}
+    </>
+  );
+}
+
+function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+}: {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}): JSX.Element {
+  return (
+    <div className="flex items-center justify-center gap-2 mt-8">
+      <button
+        type="button"
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        aria-label="Previous page"
+        className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-dash-surface border border-dash-border text-text-secondary hover:bg-dash-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <ChevronLeft className="w-4 h-4" />
+      </button>
+
+      <span className="text-text-secondary text-sm px-2">
+        Page {page} of {totalPages}
+      </span>
+
+      <button
+        type="button"
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        aria-label="Next page"
+        className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-dash-surface border border-dash-border text-text-secondary hover:bg-dash-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <ChevronRight className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}
+
+export default ProProjectsPage;

--- a/apps/web/src/components/dashboard/Sidebar.tsx
+++ b/apps/web/src/components/dashboard/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   PlayIcon,
   Squares2X2Icon,
   BookOpenIcon,
+  CubeIcon,
   ChevronDownIcon,
   LockClosedIcon,
   AcademicCapIcon,
@@ -91,6 +92,12 @@ const PREMIUM_ROUTES: RouteConfig[] = [
     path: "/dashboard/pro/refs",
     label: "Pro Refs",
     icon: <BookOpenIcon className="size-5" />,
+    badge: "New",
+  },
+  {
+    path: "/dashboard/pro/projects",
+    label: "Pro Projects",
+    icon: <CubeIcon className="size-5" />,
     badge: "New",
   },
 ];

--- a/apps/web/src/components/landing-sections/footer.tsx
+++ b/apps/web/src/components/landing-sections/footer.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { Globe } from "lucide-react";
 import { Twitter, Email, Discord, Youtube, Github, OnlyFans } from "../icons/icons";
 import Link from "next/link";
 import Image from "next/image";
@@ -36,7 +37,16 @@ const Footer = () => {
                 Opensox AI
               </h4>
             </div>
-            <div className="flex items-center gap-2">
+            <Link
+              href="https://www.jackedaj.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                handleSocialClick("https://www.jackedaj.com/", "jackedAJ")
+              }
+              className="flex items-center gap-2 text-[#b1b1b1] hover:text-white transition-colors"
+              aria-label="jackedAJ website (opens in a new tab)"
+            >
               <Image
                 src="/ajeetunc.webp"
                 alt="ajeetunc"
@@ -44,10 +54,8 @@ const Footer = () => {
                 height={32}
                 className="rounded-full object-cover object-[center_20%] aspect-square w-8 h-8"
               />
-              <span className="text-[#b1b1b1] text-xs font-mono">
-                by jackedAJ
-              </span>
-            </div>
+              <span className="text-xs font-mono">by jackedAJ</span>
+            </Link>
           </div>
 
           {/* Grid Layout - Right */}
@@ -150,6 +158,20 @@ const Footer = () => {
                 Socials
               </h3>
               <div className="flex flex-col gap-2">
+                <Link
+                  href="https://www.jackedaj.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    handleSocialClick("https://www.jackedaj.com/", "jackedAJ")
+                  }
+                  className="text-[#b1b1b1] hover:text-white transition-colors text-xs flex items-center gap-1.5"
+                >
+                  <span className="w-3.5 flex items-center justify-center">
+                    <Globe className="size-3.5" aria-hidden="true" />
+                  </span>
+                  jackedAJ
+                </Link>
                 <Link
                   href="https://x.com/jackedAJ"
                   target="_blank"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,13 +22,12 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"
       ],
       "@types/*": [
-        "types/*"
+        "./types/*"
       ],
       "@opensox/shared/*": [
         "../../packages/shared/src/*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Pro Projects” dashboard for subscribed users with searchable, paginated results and external project-quality cards.
  * Added a premium navigation item for “Pro Projects” (with a New badge).
  * Introduced an admin “Pro Projects CMS” page to create, edit, delete, and drag-and-drop reorder projects.
  * Added admin-backed endpoints to support listing, editing, reordering, and removal.
  * Updated the admin dashboard to display the latest pro member email.
  * Refreshed the landing footer social attribution/link targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->