### PR TITLE
fix: scroll restoration when navigating back from an OSS program detail page to the listing page

### DIFF
--- a/apps/web/src/app/(main)/dashboard/layout.tsx
+++ b/apps/web/src/app/(main)/dashboard/layout.tsx
@@ -45,7 +45,7 @@ export default function DashboardLayout({
                 Opensox
               </Link>
             </div>
-            <main className="flex-1 h-full overflow-auto bg-ox-content">
+            <main id="dashboard-scroll-container" className="flex-1 h-full overflow-auto bg-ox-content">
               {children}
             </main>
           </div>
@@ -64,7 +64,7 @@ export default function DashboardLayout({
               Opensox
             </Link>
           </div>
-          <main className="flex-1 h-full overflow-auto bg-ox-content">
+          <main id="dashboard-scroll-container" className="flex-1 h-full overflow-auto bg-ox-content">
             {children}
           </main>
         </div>

--- a/apps/web/src/app/(main)/dashboard/oss-programs/ProgramsList.tsx
+++ b/apps/web/src/app/(main)/dashboard/oss-programs/ProgramsList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { Program } from "@/data/oss-programs/types";
 import { SearchInput, TagFilter, ProgramCard } from "@/components/oss-programs";
 
@@ -12,6 +12,16 @@ interface ProgramsListProps {
 export default function ProgramsList({ programs, tags }: ProgramsListProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    const savedScroll = sessionStorage.getItem("oss-programs-scroll");
+
+    if (savedScroll) {
+      const scrollContainer = document.getElementById("dashboard-scroll-container");
+      scrollContainer?.scrollTo(0, Number(savedScroll));
+      sessionStorage.removeItem("oss-programs-scroll");
+    }
+  }, []);
 
   // Memoize handlers to prevent child re-renders
   const handleSearchChange = useCallback((value: string) => {

--- a/apps/web/src/components/oss-programs/ProgramCard.tsx
+++ b/apps/web/src/components/oss-programs/ProgramCard.tsx
@@ -12,7 +12,11 @@ function ProgramCard({ program }: ProgramCardProps) {
     <Link
       href={`/dashboard/oss-programs/${program.slug}`}
       onClick={() => {
-        sessionStorage.setItem("oss-program-scroll", String(window.scrollY));
+        const scrollContainer = document.getElementById("dashboard-scroll-container");
+        sessionStorage.setItem(
+          "oss-programs-scroll",
+          String(scrollContainer?.scrollTop ?? window.scrollY)
+        );
       }}
       className="group block w-full min-w-0"
     >

--- a/apps/web/src/components/oss-programs/ProgramCard.tsx
+++ b/apps/web/src/components/oss-programs/ProgramCard.tsx
@@ -11,6 +11,9 @@ function ProgramCard({ program }: ProgramCardProps) {
   return (
     <Link
       href={`/dashboard/oss-programs/${program.slug}`}
+      onClick={() => {
+        sessionStorage.setItem("oss-program-scroll", String(window.scrollY));
+      }}
       className="group block w-full min-w-0"
     >
       <div className="w-full bg-dash-surface border border-dash-border rounded-xl px-4 py-3 md:px-5 md:py-4 hover:border-brand-purple/50 hover:bg-dash-hover transition-all duration-200 flex items-center justify-between gap-3 md:gap-4 min-w-0">


### PR DESCRIPTION
Fixes #437 
 
While coming back to the oss program detail page to the listing page, the scroll should also restore to the same place as it was before.

### here is the demo-

[Screencast from 2026-07-14 01-47-38.webm](https://github.com/user-attachments/assets/6087b52b-79f1-4f64-ae80-ebf272646f02)

### what's changed

- Saves the dashboard scroll container position before opening a program detail page.
- Restores the saved scroll position when the OSS programs list mounts.
- Adds a stable `id` to the dashboard scroll container instead of relying on a generic `main` selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the dashboard’s scroll position when navigating away from and returning to the OSS programs list.
  * Restored the saved position consistently across dashboard layouts and screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->