### PR TITLE
fix: exclude archived repositories from project search

### DIFF
--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -51,6 +51,8 @@ export const projectService = {
     queryParts.push(`is:organization`);
     queryParts.push(`is:public`);
     queryParts.push(`fork:true`);
+    queryParts.push(`archived:false`);
+  
 
     const searchQueryString = queryParts.join(" ");
 


### PR DESCRIPTION
## Summary

- Exclude archived GitHub repositories from project search results.
- Added the `archived:false` GitHub search qualifier to the default repository filters.

closes #440 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived GitHub repositories are no longer included when fetching projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->