### PR TITLE
Update pitch scale from 177 to 83 people

### DIFF
--- a/apps/web/src/app/(main)/(landing)/pitch/page.tsx
+++ b/apps/web/src/app/(main)/(landing)/pitch/page.tsx
@@ -258,8 +258,8 @@ const Pitch = () => {
                   .
                 </p>
                 <p>how small?</p>
-                <p className="text-brand-purple-light">177 people. a month. only.</p>
-                <p>but why 177?</p>
+                <p className="text-brand-purple-light">83 people. a month. only.</p>
+                <p>but why 83?</p>
                 <p>
                   as per the calculations on the number of current members in
                   the opensox pro community,
@@ -270,7 +270,7 @@ const Pitch = () => {
                 <p>and the rest 20% join as a hobby.</p>
                 <p>they&apos;re already professionals in something else.</p>
                 <p>
-                  so 177 is the number i can manage. and give you my personal
+                  so 83 is the number i can manage. and give you my personal
                   attention.
                 </p>
               </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the monthly capacity number on the pitch page `#my-scale` section from 177 to 83 in all three mentions:

- "83 people. a month. only."
- "but why 83?"
- "so 83 is the number i can manage..."

No other copy in the repo referenced this figure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03efb-7e91-70df-8d17-40088d6288fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03efb-7e91-70df-8d17-40088d6288fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Opensox Pro capacity information on the pitch page from 177 to 83 people.
  * Revised the accompanying explanation to reflect the updated capacity and personal attention provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->